### PR TITLE
fix to Building ladders bug #43 and finish Diplomatic Colors

### DIFF
--- a/Module/module_presentations.py
+++ b/Module/module_presentations.py
@@ -13798,6 +13798,7 @@ presentations = [
             (faction_slot_eq, ":cur_faction", slot_faction_state, sfs_active),
             (overlay_add_item, "$g_presentation_obj_1", s0),
           (else_try),
+            (neg|is_between, ":cur_faction", enhanced_factions_begin, enhanced_factions_end),##KOMKE not enhanced factions
             (overlay_add_item, "$g_presentation_obj_1", s0),
           (try_end),
         (try_end),

--- a/Module/module_simple_triggers.py
+++ b/Module/module_simple_triggers.py
@@ -44,27 +44,28 @@ simple_triggers = [
    [
     ]),
 
-  (1,
-   [
-      ######### rafi what's this?
-      ######### (try_begin),
-        ######### (eq, "$training_ground_position_changed", 0),
-        ######### (assign, "$training_ground_position_changed", 1),
-        ######### (position_set_x, pos0, 7050),
-        ######### (position_set_y, pos0, 7200),
-        ######### (party_set_position, "p_training_ground_3", pos0),
-      ######### (try_end),
-      
-      (gt, "$auto_besiege_town",0),
-      (gt, "$g_player_besiege_town", 0),
-      (ge, "$g_siege_method", 1),
-      (store_current_hours, ":cur_hours"),
-      (eq, "$g_siege_force_wait", 0),
-      (ge, ":cur_hours", "$g_siege_method_finish_hours"),
-      (neg|is_currently_night),
-      (rest_for_hours, 0, 0, 0), ######stop resting
-    ]),
-
+####### NEW v2.9-KOMKE START- this trigger commented out, no longer necessary due to later trigger, (see NEW v2.9-KOMKE)
+  # (1,
+  #  [
+  #     ######### rafi what's this?
+  #     ######### (try_begin),
+  #       ######### (eq, "$training_ground_position_changed", 0),
+  #       ######### (assign, "$training_ground_position_changed", 1),
+  #       ######### (position_set_x, pos0, 7050),
+  #       ######### (position_set_y, pos0, 7200),
+  #       ######### (party_set_position, "p_training_ground_3", pos0),
+  #     ######### (try_end),
+  # 
+  #     (gt, "$auto_besiege_town",0),
+  #     (gt, "$g_player_besiege_town", 0),
+  #     (ge, "$g_siege_method", 1),
+  #     (store_current_hours, ":cur_hours"),
+  #     (eq, "$g_siege_force_wait", 0),
+  #     (ge, ":cur_hours", "$g_siege_method_finish_hours"),
+  #     (neg|is_currently_night),
+  #     (rest_for_hours, 0, 0, 0), ######stop resting
+  #   ]),
+####### NEW v2.9-KOMKE END- 
   (0,
    [
       (try_begin),
@@ -154,6 +155,7 @@ simple_triggers = [
      (try_end),
      ]),
 
+####### NEW v2.9-KOMKE this trigger makes the previous no longer necessary(see NEW v2.9-KOMKE)
 (0.25,
    [
       (gt, "$auto_besiege_town",0),
@@ -174,6 +176,7 @@ simple_triggers = [
         (str_store_party_name_link, s1, "$g_player_besiege_town"),
         (display_message, "@You cannot maintain your siege of {s1} from this distance. You risk your lines breaking."),
       (else_try),
+        (eq, "$g_siege_force_wait", 0),####### NEW v2.9-KOMKE if it's waiting 24 hours don't stop (force wait 1)
         (store_current_hours, ":cur_hours"),
         (ge, ":cur_hours", "$g_siege_method_finish_hours"),
         (neg|is_currently_night),


### PR DESCRIPTION
.- Added a line to check if player is waiting 24 hours when besieging
.-Commented out other trigger which was doing the same, should have been removed when the new trigger was added
.-Diplomatic colors: enhanced factions only appear in loop when active