### PR TITLE
fix "Merc hiring bug #21"

### DIFF
--- a/Module/module_game_menus.py
+++ b/Module/module_game_menus.py
@@ -22816,17 +22816,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_quarters_minor_genoese, 1),
          (str_store_string, s20, "@Genoese Crossbowmen (Normal)"),
-         (assign, "$current_mercs", "pt_company_genoese_1"),    
+         # (assign, "$current_mercs", "pt_company_genoese_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_major_genoese, 1),
          (str_store_string, s20, "@Genoese Crossbowmen (Large)"),
-         (assign, "$current_mercs", "pt_company_genoese_2"),    
+         # (assign, "$current_mercs", "pt_company_genoese_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_hq_genoese, 1),
          (str_store_string, s20, "@Genoese Crossbowmen (Very Large)"),
-         (assign, "$current_mercs", "pt_company_genoese_3"),    
+         # (assign, "$current_mercs", "pt_company_genoese_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -22842,6 +22842,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_minor_genoese, 1),
+         (assign, "$current_mercs", "pt_company_genoese_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_major_genoese, 1),
+         (assign, "$current_mercs", "pt_company_genoese_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_hq_genoese, 1),
+         (assign, "$current_mercs", "pt_company_genoese_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -22900,17 +22912,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_outpost_minor_finnish, 1),
          (str_store_string, s21, "@Finnish mercenaries (Normal)"),
-         (assign, "$current_mercs", "pt_company_finnish_1"),    
+         # (assign, "$current_mercs", "pt_company_finnish_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_large_finnish, 1),
          (str_store_string, s21, "@Finnish mercenaries (Large)"),
-         (assign, "$current_mercs", "pt_company_finnish_2"),    
+         # (assign, "$current_mercs", "pt_company_finnish_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_major_finnish, 1),
          (str_store_string, s21, "@Finnish mercenaries (Very Large)"),
-         (assign, "$current_mercs", "pt_company_finnish_3"),    
+         # (assign, "$current_mercs", "pt_company_finnish_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -22926,6 +22938,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_minor_finnish, 1),
+         (assign, "$current_mercs", "pt_company_finnish_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_large_finnish, 1),
+         (assign, "$current_mercs", "pt_company_finnish_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_major_finnish, 1),
+         (assign, "$current_mercs", "pt_company_finnish_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -22984,17 +23008,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_outpost_minor_crusader_turcopole, 1),
          (str_store_string, s22, "@Turcopoles (Normal)"),
-         (assign, "$current_mercs", "pt_company_turkopoles_1"),    
+         #(assign, "$current_mercs", "pt_company_turkopoles_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_large_crusader_turcopole, 1),
          (str_store_string, s22, "@Turcopoles (Large)"),
-         (assign, "$current_mercs", "pt_company_turkopoles_2"),    
+         #(assign, "$current_mercs", "pt_company_turkopoles_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_major_crusader_turcopole, 1),
          (str_store_string, s22, "@Turcopoles (Very Large)"),
-         (assign, "$current_mercs", "pt_company_turkopoles_3"),    
+         #(assign, "$current_mercs", "pt_company_turkopoles_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -23010,6 +23034,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_minor_crusader_turcopole, 1),
+         (assign, "$current_mercs", "pt_company_turkopoles_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_large_crusader_turcopole, 1),
+         (assign, "$current_mercs", "pt_company_turkopoles_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_major_crusader_turcopole, 1),
+         (assign, "$current_mercs", "pt_company_turkopoles_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23068,17 +23104,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_quarters_minor_brabantine, 1),
          (str_store_string, s23, "@Brabantine mercenaries (Normal)"),
-         (assign, "$current_mercs", "pt_company_brabantine_1"),    
+         # (assign, "$current_mercs", "pt_company_brabantine_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_major_brabantine, 1),
          (str_store_string, s23, "@Brabantine mercenaries (Large)"),
-         (assign, "$current_mercs", "pt_company_brabantine_2"),    
+         # (assign, "$current_mercs", "pt_company_brabantine_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_hq_brabantine, 1),
          (str_store_string, s23, "@Brabantine mercenaries (Very Large)"),
-         (assign, "$current_mercs", "pt_company_brabantine_3"),    
+         # (assign, "$current_mercs", "pt_company_brabantine_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -23094,6 +23130,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_minor_brabantine, 1),
+         (assign, "$current_mercs", "pt_company_brabantine_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_major_brabantine, 1),
+         (assign, "$current_mercs", "pt_company_brabantine_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_hq_brabantine, 1),
+         (assign, "$current_mercs", "pt_company_brabantine_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23157,17 +23205,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_outpost_minor_welsh_kern, 1),
          (str_store_string, s24, "@Welsh mercenaries (Normal)"),
-         (assign, "$current_mercs", "pt_company_welsh_1"),    
+         # (assign, "$current_mercs", "pt_company_welsh_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_large_welsh_kern, 1),
          (str_store_string, s24, "@Welsh mercenaries (Large)"),
-         (assign, "$current_mercs", "pt_company_welsh_2"),    
+         # (assign, "$current_mercs", "pt_company_welsh_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_major_welsh_kern, 1),
          (str_store_string, s24, "@Welsh mercenaries (Very Large)"),
-         (assign, "$current_mercs", "pt_company_welsh_3"),    
+         # (assign, "$current_mercs", "pt_company_welsh_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -23183,6 +23231,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_minor_welsh_kern, 1),
+         (assign, "$current_mercs", "pt_company_welsh_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_large_welsh_kern, 1),
+         (assign, "$current_mercs", "pt_company_welsh_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_major_welsh_kern, 1),
+         (assign, "$current_mercs", "pt_company_welsh_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23243,17 +23303,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_outpost_minor_gaelic, 1),
          (str_store_string, s25, "@Gaelic mercenaries (Normal)"),
-         (assign, "$current_mercs", "pt_generic_gaelic_1"),    
+         # (assign, "$current_mercs", "pt_generic_gaelic_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_large_gaelic, 1),
          (str_store_string, s25, "@Gaelic mercenaries (Large)"),
-         (assign, "$current_mercs", "pt_generic_gaelic_2"),    
+         # (assign, "$current_mercs", "pt_generic_gaelic_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_major_gaelic, 1),
          (str_store_string, s25, "@Gaelic mercenaries (Very Large)"),
-         (assign, "$current_mercs", "pt_generic_gaelic_3"),    
+         # (assign, "$current_mercs", "pt_generic_gaelic_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -23269,6 +23329,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_minor_gaelic, 1),
+         (assign, "$current_mercs", "pt_generic_gaelic_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_large_gaelic, 1),
+         (assign, "$current_mercs", "pt_generic_gaelic_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_major_gaelic, 1),
+         (assign, "$current_mercs", "pt_generic_gaelic_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23330,17 +23402,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_cuman, 1),
          (str_store_string, s26, "@Cumans (Normal)"),
-         (assign, "$current_mercs", "pt_company_cuman_1"),    
+         # (assign, "$current_mercs", "pt_company_cuman_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_cuman, 1),
          (str_store_string, s26, "@Cumans (Large)"),
-         (assign, "$current_mercs", "pt_company_cuman_2"),    
+         # (assign, "$current_mercs", "pt_company_cuman_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_cuman, 1),
          (str_store_string, s26, "@Cumans (Very Large)"),
-         (assign, "$current_mercs", "pt_company_cuman_3"),    
+         # (assign, "$current_mercs", "pt_company_cuman_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -23356,6 +23428,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_cuman, 1),
+         (assign, "$current_mercs", "pt_company_cuman_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_cuman, 1),
+         (assign, "$current_mercs", "pt_company_cuman_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_cuman, 1),
+         (assign, "$current_mercs", "pt_company_cuman_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23415,17 +23499,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_kipchak, 1),
          (str_store_string, s27, "@Kipchaks (Normal)"),
-         (assign, "$current_mercs", "pt_company_kipchak_1"),    
+         # (assign, "$current_mercs", "pt_company_kipchak_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_kipchak, 1),
          (str_store_string, s27, "@Kipchaks (Large)"),
-         (assign, "$current_mercs", "pt_company_kipchak_2"),    
+         # (assign, "$current_mercs", "pt_company_kipchak_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_kipchak, 1),
          (str_store_string, s27, "@Kipchaks (Very Large)"),
-         (assign, "$current_mercs", "pt_company_kipchak_3"),    
+         # (assign, "$current_mercs", "pt_company_kipchak_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -23441,6 +23525,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_kipchak, 1),
+         (assign, "$current_mercs", "pt_company_kipchak_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_kipchak, 1),
+         (assign, "$current_mercs", "pt_company_kipchak_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_kipchak, 1),
+         (assign, "$current_mercs", "pt_company_kipchak_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23500,17 +23596,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_mongol, 1),
          (str_store_string, s28, "@Mongols (Normal)"),
-         (assign, "$current_mercs", "pt_company_mongol_1"),    
+         # (assign, "$current_mercs", "pt_company_mongol_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_mongol, 1),
          (str_store_string, s28, "@Mongols (Large)"),
-         (assign, "$current_mercs", "pt_company_mongol_2"),    
+         # (assign, "$current_mercs", "pt_company_mongol_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_mongol, 1),
          (str_store_string, s28, "@Mongols (Very Large)"),
-         (assign, "$current_mercs", "pt_company_mongol_3"),    
+         # (assign, "$current_mercs", "pt_company_mongol_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -23526,6 +23622,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_mongol, 1),
+         (assign, "$current_mercs", "pt_company_mongol_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_mongol, 1),
+         (assign, "$current_mercs", "pt_company_mongol_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_mongol, 1),
+         (assign, "$current_mercs", "pt_company_mongol_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23586,17 +23694,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_georgian, 1),
          (str_store_string, s29, "@Georgians (Normal)"),
-         (assign, "$current_mercs", "pt_company_georgian_1"),    
+         # (assign, "$current_mercs", "pt_company_georgian_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_georgian, 1),
          (str_store_string, s29, "@Georgians (Large)"),
-         (assign, "$current_mercs", "pt_company_georgian_2"),    
+         # (assign, "$current_mercs", "pt_company_georgian_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_georgian, 1),
          (str_store_string, s29, "@Georgians (Very Large)"),
-         (assign, "$current_mercs", "pt_company_georgian_3"),    
+         # (assign, "$current_mercs", "pt_company_georgian_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -23612,6 +23720,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_georgian, 1),
+         (assign, "$current_mercs", "pt_company_georgian_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_georgian, 1),
+         (assign, "$current_mercs", "pt_company_georgian_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_georgian, 1),
+         (assign, "$current_mercs", "pt_company_georgian_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23673,17 +23793,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_kwarezmian, 1),
          (str_store_string, s30, "@Kwarezmians (Normal)"),
-         (assign, "$current_mercs", "pt_company_kwarezmian_1"),    
+         # (assign, "$current_mercs", "pt_company_kwarezmian_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_kwarezmian, 1),
          (str_store_string, s30, "@Kwarezmians (Large)"),
-         (assign, "$current_mercs", "pt_company_kwarezmian_2"),    
+         # (assign, "$current_mercs", "pt_company_kwarezmian_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_kwarezmian, 1),
          (str_store_string, s30, "@Kwarezmians (Very Large)"),
-         (assign, "$current_mercs", "pt_company_kwarezmian_3"),    
+         # (assign, "$current_mercs", "pt_company_kwarezmian_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
        (try_end),
@@ -23699,6 +23819,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg8),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_kwarezmian, 1),
+         (assign, "$current_mercs", "pt_company_kwarezmian_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_kwarezmian, 1),
+         (assign, "$current_mercs", "pt_company_kwarezmian_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_kwarezmian, 1),
+         (assign, "$current_mercs", "pt_company_kwarezmian_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23755,22 +23887,22 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_teutonic, 1),
          (str_store_string, s31, "@The Teutonic Knights (Small)"),
-         (assign, "$current_mercs", "pt_company_teutonic_1"),    
+         # (assign, "$current_mercs", "pt_company_teutonic_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_teutonic, 1),
          (str_store_string, s31, "@The Teutonic Knights (Medium)"),
-         (assign, "$current_mercs", "pt_company_teutonic_2"),    
+         # (assign, "$current_mercs", "pt_company_teutonic_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_teutonic, 1),
          (str_store_string, s31, "@The Teutonic Knights (Large)"),
-         (assign, "$current_mercs", "pt_company_teutonic_3"),    
+         # (assign, "$current_mercs", "pt_company_teutonic_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_teutonic, 1),
          (str_store_string, s31, "@The Teutonic Knights (Very Large)"),
-         (assign, "$current_mercs", "pt_company_teutonic_4"),    
+         # (assign, "$current_mercs", "pt_company_teutonic_4"),####### NEW v3.0-KOMKE mercs assigned in consequences block
           
          
 ############################################
@@ -23787,6 +23919,21 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_3"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_4"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23833,22 +23980,22 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_templar, 1),
          (str_store_string, s32, "@The Templar Knights (Small)"),
-         (assign, "$current_mercs", "pt_company_templar_1"),    
+         # (assign, "$current_mercs", "pt_company_templar_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_templar, 1),
          (str_store_string, s32, "@The Templar Knights (Medium)"),
-         (assign, "$current_mercs", "pt_company_templar_2"),    
+         # (assign, "$current_mercs", "pt_company_templar_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_templar, 1),
          (str_store_string, s32, "@The Templar Knights (Large)"),
-         (assign, "$current_mercs", "pt_company_templar_3"),    
+         # (assign, "$current_mercs", "pt_company_templar_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_templar, 1),
          (str_store_string, s32, "@The Templar Knights (Very Large)"),
-         (assign, "$current_mercs", "pt_company_templar_4"),    
+         # (assign, "$current_mercs", "pt_company_templar_4"),####### NEW v3.0-KOMKE mercs assigned in consequences block
           
          
 ############################################
@@ -23865,6 +24012,21 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_3"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_4"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23911,22 +24073,22 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_hospitaller, 1),
          (str_store_string, s33, "@The Hospitaller Knights (Small)"),
-         (assign, "$current_mercs", "pt_company_hospitaller_1"),    
+         # (assign, "$current_mercs", "pt_company_hospitaller_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hospitaller, 1),
          (str_store_string, s33, "@The Hospitaller Knights (Medium)"),
-         (assign, "$current_mercs", "pt_company_hospitaller_2"),    
+         # (assign, "$current_mercs", "pt_company_hospitaller_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_hospitaller, 1),
          (str_store_string, s33, "@The Hospitaller Knights (Large)"),
-         (assign, "$current_mercs", "pt_company_hospitaller_3"),    
+         # (assign, "$current_mercs", "pt_company_hospitaller_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_hospitaller, 1),
          (str_store_string, s33, "@The Hospitaller Knights (Very Large)"),
-         (assign, "$current_mercs", "pt_company_hospitaller_4"),    
+         # (assign, "$current_mercs", "pt_company_hospitaller_4"),####### NEW v3.0-KOMKE mercs assigned in consequences block
           
          
 ############################################
@@ -23943,6 +24105,21 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_3"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_4"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -23986,17 +24163,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_saint_lazarus, 1),
          (str_store_string, s34, "@The Saint Lazarus Knights (Small)"),
-         (assign, "$current_mercs", "pt_company_saint_lazarus_1"),    
+         # (assign, "$current_mercs", "pt_company_saint_lazarus_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_saint_lazarus, 1),
          (str_store_string, s34, "@The Saint Lazarus Knights (Medium)"),
-         (assign, "$current_mercs", "pt_company_saint_lazarus_2"),    
+         # (assign, "$current_mercs", "pt_company_saint_lazarus_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_saint_lazarus, 1),
          (str_store_string, s34, "@The Saint Lazarus Knights (Large)"),
-         (assign, "$current_mercs", "pt_company_saint_lazarus_3"),    
+         # (assign, "$current_mercs", "pt_company_saint_lazarus_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
           
 ############################################
        (try_end),
@@ -24012,6 +24189,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_saint_lazarus, 1),
+         (assign, "$current_mercs", "pt_company_saint_lazarus_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_saint_lazarus, 1),
+         (assign, "$current_mercs", "pt_company_saint_lazarus_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_saint_lazarus, 1),
+         (assign, "$current_mercs", "pt_company_saint_lazarus_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -24057,17 +24246,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_santiago, 1),
          (str_store_string, s35, "@The Santiago Knights (Small)"),
-         (assign, "$current_mercs", "pt_company_santiago_1"),    
+         # (assign, "$current_mercs", "pt_company_santiago_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_santiago, 1),
          (str_store_string, s35, "@The Santiago Knights (Medium)"),
-         (assign, "$current_mercs", "pt_company_santiago_2"),    
+         # (assign, "$current_mercs", "pt_company_santiago_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_santiago, 1),
          (str_store_string, s35, "@The Santiago Knights (Large)"),
-         (assign, "$current_mercs", "pt_company_santiago_3"),    
+         # (assign, "$current_mercs", "pt_company_santiago_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
           
 ############################################
        (try_end),
@@ -24083,6 +24272,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_santiago, 1),
+         (assign, "$current_mercs", "pt_company_santiago_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_santiago, 1),
+         (assign, "$current_mercs", "pt_company_santiago_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_santiago, 1),
+         (assign, "$current_mercs", "pt_company_santiago_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -24126,17 +24327,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_calatrava, 1),
          (str_store_string, s36, "@The Calatrava Knights (Small)"),
-         (assign, "$current_mercs", "pt_company_calatrava_1"),    
+         # (assign, "$current_mercs", "pt_company_calatrava_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_calatrava, 1),
          (str_store_string, s36, "@The Calatrava Knights (Medium)"),
-         (assign, "$current_mercs", "pt_company_calatrava_2"),    
+         # (assign, "$current_mercs", "pt_company_calatrava_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_calatrava, 1),
          (str_store_string, s36, "@The Calatrava Knights (Large)"),
-         (assign, "$current_mercs", "pt_company_calatrava_3"),    
+         # (assign, "$current_mercs", "pt_company_calatrava_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
           
 ############################################
        (try_end),
@@ -24152,6 +24353,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_calatrava, 1),
+         (assign, "$current_mercs", "pt_company_calatrava_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_calatrava, 1),
+         (assign, "$current_mercs", "pt_company_calatrava_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_calatrava, 1),
+         (assign, "$current_mercs", "pt_company_calatrava_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -24194,17 +24407,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_saint_thomas, 1),
          (str_store_string, s37, "@The Saint Thomas Knights (Small)"),
-         (assign, "$current_mercs", "pt_company_saint_thomas_1"),    
+         # (assign, "$current_mercs", "pt_company_saint_thomas_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_saint_thomas, 1),
          (str_store_string, s37, "@The Saint Thomas Knights (Medium)"),
-         (assign, "$current_mercs", "pt_company_saint_thomas_2"),    
+         # (assign, "$current_mercs", "pt_company_saint_thomas_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_saint_thomas, 1),
          (str_store_string, s37, "@The Saint Thomas Knights (Large)"),
-         (assign, "$current_mercs", "pt_company_saint_thomas_3"),    
+         # (assign, "$current_mercs", "pt_company_saint_thomas_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
           
 ############################################
        (try_end),
@@ -24220,6 +24433,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_saint_thomas, 1),
+         (assign, "$current_mercs", "pt_company_saint_thomas_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_saint_thomas, 1),
+         (assign, "$current_mercs", "pt_company_saint_thomas_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_saint_thomas, 1),
+         (assign, "$current_mercs", "pt_company_saint_thomas_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -24265,12 +24490,12 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_quarters_major_varangian, 1),
          (str_store_string, s38, "@The Varangians (Normal)"),
-         (assign, "$current_mercs", "pt_company_varangian_1"),    
+         # (assign, "$current_mercs", "pt_company_varangian_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_hq_varangian, 1),
          (str_store_string, s38, "@The Varangians (Large)"),
-         (assign, "$current_mercs", "pt_company_varangian_2"),    
+         # (assign, "$current_mercs", "pt_company_varangian_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
           
 ############################################
@@ -24287,6 +24512,15 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_major_varangian, 1),
+         (assign, "$current_mercs", "pt_company_varangian_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_hq_varangian, 1),
+         (assign, "$current_mercs", "pt_company_varangian_2"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -24330,17 +24564,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_quarters_minor_cataphract, 1),
          (str_store_string, s39, "@The Cataphracts (Small)"),
-         (assign, "$current_mercs", "pt_company_cataphract_1"),    
+         # (assign, "$current_mercs", "pt_company_cataphract_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_major_cataphract, 1),
          (str_store_string, s39, "@The Cataphracts (Medium)"),
-         (assign, "$current_mercs", "pt_company_cataphract_2"),    
+         # (assign, "$current_mercs", "pt_company_cataphract_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_hq_cataphract, 1),
          (str_store_string, s39, "@The Cataphracts (Large)"),
-         (assign, "$current_mercs", "pt_company_cataphract_3"),    
+         # (assign, "$current_mercs", "pt_company_cataphract_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
           
 ############################################
        (try_end),
@@ -24356,6 +24590,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_minor_cataphract, 1),
+         (assign, "$current_mercs", "pt_company_cataphract_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_major_cataphract, 1),
+         (assign, "$current_mercs", "pt_company_cataphract_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_hq_cataphract, 1),
+         (assign, "$current_mercs", "pt_company_cataphract_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -24402,17 +24648,17 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_quarters_minor_mamluk, 1),
          (str_store_string, s40, "@The Mamluks (Small)"),
-         (assign, "$current_mercs", "pt_company_mamlukes_1"),    
+         # (assign, "$current_mercs", "pt_company_mamlukes_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_major_mamluk, 1),
          (str_store_string, s40, "@The Mamluks (Medium)"),
-         (assign, "$current_mercs", "pt_company_mamlukes_2"),    
+         # (assign, "$current_mercs", "pt_company_mamlukes_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_hq_mamluk, 1),
          (str_store_string, s40, "@The Mamluks (Large)"),
-         (assign, "$current_mercs", "pt_company_mamlukes_3"),    
+         # (assign, "$current_mercs", "pt_company_mamlukes_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
           
 ############################################
        (try_end),
@@ -24428,6 +24674,18 @@ game_menus = [ #
          (troop_remove_gold, "trp_player", reg9),
        (try_end),
        
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_minor_mamluk, 1),
+         (assign, "$current_mercs", "pt_company_mamlukes_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_major_mamluk, 1),
+         (assign, "$current_mercs", "pt_company_mamlukes_2"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_hq_mamluk, 1),
+         (assign, "$current_mercs", "pt_company_mamlukes_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        ##(party_set_slot, "$current_town", slot_regional_mercs, generic_euro), #######TEMP!!
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
@@ -24480,12 +24738,12 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_teutonic, 1),
          (str_store_string, s45, "@The Teutonic Knights Auxiliaries (Normal)"),
-         (assign, "$current_mercs", "pt_company_teutonic_aux_1"),
+         # (assign, "$current_mercs", "pt_company_teutonic_aux_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
 
       (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_teutonic, 1),
          (str_store_string, s45, "@The Teutonic Knights Auxiliaries (Large)"),
-         (assign, "$current_mercs", "pt_company_teutonic_aux_2"),
+         # (assign, "$current_mercs", "pt_company_teutonic_aux_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
        (try_end),
        
      ], "Call upon {s45}. {s9}",
@@ -24493,6 +24751,15 @@ game_menus = [ #
        (party_get_slot, ":manpower", "$current_town", slot_spec_mercs_number_teutonic_aux),
        (val_sub, ":manpower", 1),
        (party_set_slot, "$current_town", slot_spec_mercs_number_teutonic_aux, ":manpower"),
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_aux_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_aux_2"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
        
@@ -24553,12 +24820,12 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_templar, 1),
          (str_store_string, s46, "@The Knights Templar Auxiliaries (Normal)"),
-         (assign, "$current_mercs", "pt_company_templar_aux_1"),
+         # (assign, "$current_mercs", "pt_company_templar_aux_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_templar, 1),
          (str_store_string, s46, "@The Knights Templar Auxiliaries (Large)"),
-         (assign, "$current_mercs", "pt_company_templar_aux_2"),
+         # (assign, "$current_mercs", "pt_company_templar_aux_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
        (try_end),
        
      ], "Call upon {s46}. {s9}",
@@ -24566,6 +24833,15 @@ game_menus = [ #
        (party_get_slot, ":manpower", "$current_town", slot_spec_mercs_number_templar_aux),
        (val_sub, ":manpower", 1),
        (party_set_slot, "$current_town", slot_spec_mercs_number_templar_aux, ":manpower"),
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_aux_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_aux_2"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
        
@@ -24625,12 +24901,12 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_hospitaller, 1),
          (str_store_string, s47, "@The Knights Hospitaller Auxiliaries (Normal)"),
-         (assign, "$current_mercs", "pt_company_hospitaller_aux_1"),
+         # (assign, "$current_mercs", "pt_company_hospitaller_aux_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_hospitaller, 1),
          (str_store_string, s47, "@The Knights Hospitaller Auxiliaries (Large)"),
-         (assign, "$current_mercs", "pt_company_hospitaller_aux_2"),
+         # (assign, "$current_mercs", "pt_company_hospitaller_aux_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
        (try_end),
        
      ], "Call upon {s47}. {s9}",
@@ -24638,6 +24914,15 @@ game_menus = [ #
        (party_get_slot, ":manpower", "$current_town", slot_spec_mercs_number_hospitaller_aux),
        (val_sub, ":manpower", 1),
        (party_set_slot, "$current_town", slot_spec_mercs_number_hospitaller_aux, ":manpower"),
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_aux_1"),
+       (else_try),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_aux_2"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
        
@@ -24711,14 +24996,14 @@ game_menus = [ #
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_teutonic"),
          (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
          (str_store_string, s50, "@Euro Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_euro_1"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_euro_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (this_or_next|faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_western"),
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_teutonic"),
          (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
          (str_store_string, s50, "@Euro Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_euro_2"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_euro_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
 
          
 #######################################
@@ -24726,13 +25011,13 @@ game_menus = [ #
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_nordic"),
          (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
          (str_store_string, s50, "@Scandinavian Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_scandinavian_1"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_scandinavian_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_nordic"),
          (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
          (str_store_string, s50, "@Scandinavian Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_scandinavian_2"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_scandinavian_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 #######################################
@@ -24740,13 +25025,13 @@ game_menus = [ #
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_iberian"),
          (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
          (str_store_string, s50, "@Iberian Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_iberian_1"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_iberian_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
        
        (else_try),
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_iberian"),
          (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
          (str_store_string, s50, "@Iberian Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_iberian_2"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_iberian_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 #######################################
@@ -24754,13 +25039,13 @@ game_menus = [ #
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_gaelic"),
          (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
          (str_store_string, s50, "@Gaelic Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_gaelic_1"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_gaelic_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
        
        (else_try),
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_gaelic"),
          (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
          (str_store_string, s50, "@Gaelic Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_gaelic_2"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_gaelic_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 #######################################
@@ -24768,13 +25053,13 @@ game_menus = [ #
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_welsh"),
          (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
          (str_store_string, s50, "@Welsh Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_welsh_1"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_welsh_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
        
        (else_try),
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_welsh"),
          (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
          (str_store_string, s50, "@Welsh Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_welsh_2"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_welsh_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 #######################################
@@ -24782,13 +25067,13 @@ game_menus = [ #
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_italian"),
          (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
          (str_store_string, s50, "@Italian Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_italian_1"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_italian_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
        
        (else_try),
          (faction_slot_eq, ":cur_fief_faction", slot_faction_culture, "fac_culture_italian"),
          (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
          (str_store_string, s50, "@Italian Knights"),
-         (assign, "$current_mercs", "pt_company_knights_tournament_italian_2"),
+         # (assign, "$current_mercs", "pt_company_knights_tournament_italian_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
 
          
 ###################################### CTT TROOPS
@@ -24809,6 +25094,57 @@ game_menus = [ #
        (party_get_slot, ":manpower", "$current_town", slot_spec_mercs2_number),
        (val_sub, ":manpower", 1),
        (party_set_slot, "$current_town", slot_spec_mercs2_number, ":manpower"),
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (eq, s50, "@Euro Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_euro_1"),
+       (else_try),
+         (eq, s50, "@Euro Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_euro_2"),
+       (else_try),
+         (eq, s50, "@Scandinavian Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_scandinavian_1"),
+       (else_try),
+         (eq, s50, "@Scandinavian Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_scandinavian_2"),
+       (else_try),
+         (eq, s50, "@Iberian Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_iberian_1"),
+       (else_try),
+         (eq, s50, "@Iberian Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_iberian_2"),
+       (else_try),
+         (eq, s50, "@Gaelic Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_gaelic_1"),
+       (else_try),
+         (eq, s50, "@Gaelic Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_gaelic_2"),
+       (else_try),
+         (eq, s50, "@Welsh Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_welsh_1"),
+       (else_try),
+         (eq, s50, "@Welsh Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_welsh_2"),
+       (else_try),
+         (eq, s50, "@Italian Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_1_jousting_lists, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_italian_1"),
+       (else_try),
+         (eq, s50, "@Italian Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_tier_2_tournament_grounds, 1),
+         (assign, "$current_mercs", "pt_company_knights_tournament_italian_2"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
        (call_script, "script_fill_company_new", "$current_town", "p_main_party", "$current_mercs"),
        
        
@@ -24986,150 +25322,150 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_quarters_minor_genoese, 1),
          (str_store_string, s20, "@Genoese crossbowmen"),
-         (assign, "$current_mercs", "pt_company_genoese_1"),    
+         # (assign, "$current_mercs", "pt_company_genoese_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_major_genoese, 1),
          (str_store_string, s20, "@Genoese crossbowmen"),
-         (assign, "$current_mercs", "pt_company_genoese_2"),    
+         # (assign, "$current_mercs", "pt_company_genoese_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_hq_genoese, 1),
          (str_store_string, s20, "@Genoese crossbowmen"),
-         (assign, "$current_mercs", "pt_company_genoese_3"),    
+         # (assign, "$current_mercs", "pt_company_genoese_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_minor_crusader_turcopole, 1),
          (str_store_string, s20, "@Turkopoles"),
-         (assign, "$current_mercs", "pt_company_turkopoles_1"),    
+         # (assign, "$current_mercs", "pt_company_turkopoles_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_large_crusader_turcopole, 1),
          (str_store_string, s20, "@Turkopoles"),
-         (assign, "$current_mercs", "pt_company_turkopoles_2"),    
+         # (assign, "$current_mercs", "pt_company_turkopoles_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_major_crusader_turcopole, 1),
          (str_store_string, s20, "@Turkopoles"),
-         (assign, "$current_mercs", "pt_company_turkopoles_3"),    
+         # (assign, "$current_mercs", "pt_company_turkopoles_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_georgian, 1),
          (str_store_string, s20, "@Georgians"),
-         (assign, "$current_mercs", "pt_company_georgian_1"),    
+         # (assign, "$current_mercs", "pt_company_georgian_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_georgian, 1),
          (str_store_string, s20, "@Georgians"),
-         (assign, "$current_mercs", "pt_company_georgian_2"),    
+         # (assign, "$current_mercs", "pt_company_georgian_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_georgian, 1),
          (str_store_string, s20, "@Georgians"),
-         (assign, "$current_mercs", "pt_company_georgian_3"),    
+         # (assign, "$current_mercs", "pt_company_georgian_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_cuman, 1),
          (str_store_string, s20, "@Cumans"),
-         (assign, "$current_mercs", "pt_company_cuman_1"),    
+         # (assign, "$current_mercs", "pt_company_cuman_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_cuman, 1),
          (str_store_string, s20, "@Cumans"),
-         (assign, "$current_mercs", "pt_company_cuman_2"),    
+         # (assign, "$current_mercs", "pt_company_cuman_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_cuman, 1),
          (str_store_string, s20, "@Cumans"),
-         (assign, "$current_mercs", "pt_company_cuman_3"),    
+         # (assign, "$current_mercs", "pt_company_cuman_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_minor_brabantine, 1),
          (str_store_string, s20, "@Brabantines"),
-         (assign, "$current_mercs", "pt_company_brabantine_1"),    
+         # (assign, "$current_mercs", "pt_company_brabantine_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_major_brabantine, 1),
          (str_store_string, s20, "@Brabantines"),
-         (assign, "$current_mercs", "pt_company_brabantine_2"),    
+         # (assign, "$current_mercs", "pt_company_brabantine_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_hq_brabantine, 1),
          (str_store_string, s20, "@Brabantines"),
-         (assign, "$current_mercs", "pt_company_brabantine_3"),    
+         # (assign, "$current_mercs", "pt_company_brabantine_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_spec_mercs1, merc_sicily_muslims),
          (str_store_string, s20, "@Sicily Muslims"),
-         (assign, "$current_mercs", "pt_company_templar_3"),    
+         # (assign, "$current_mercs", "pt_company_templar_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_minor_welsh_kern, 1),
          (str_store_string, s20, "@Welsh archers"),
-         (assign, "$current_mercs", "pt_company_welsh_1"),    
+         # (assign, "$current_mercs", "pt_company_welsh_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_large_welsh_kern, 1),
          (str_store_string, s20, "@Welsh archers"),
-         (assign, "$current_mercs", "pt_company_welsh_2"),    
+         # (assign, "$current_mercs", "pt_company_welsh_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_outpost_major_welsh_kern, 1),
          (str_store_string, s20, "@Welsh archers"),
-         (assign, "$current_mercs", "pt_company_welsh_3"),    
+         # (assign, "$current_mercs", "pt_company_welsh_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_kipchak, 1),
          (str_store_string, s20, "@Kipchaks"),
-         (assign, "$current_mercs", "pt_company_kipchak_1"),    
+         # (assign, "$current_mercs", "pt_company_kipchak_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_kipchak, 1),
          (str_store_string, s20, "@Kipchaks"),
-         (assign, "$current_mercs", "pt_company_kipchak_2"),    
+         # (assign, "$current_mercs", "pt_company_kipchak_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_kipchak, 1),
          (str_store_string, s20, "@Kipchaks"),
-         (assign, "$current_mercs", "pt_company_kipchak_3"),    
+         # (assign, "$current_mercs", "pt_company_kipchak_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_spec_mercs1, merc_mordovian),
          (str_store_string, s20, "@Mordovians"),
-         (assign, "$current_mercs", "pt_company_mordovian"),    
+         # (assign, "$current_mercs", "pt_company_mordovian"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_kwarezmian, 1),
          (str_store_string, s20, "@Kwarezmians"),
-         (assign, "$current_mercs", "pt_company_kwarezmian_1"),    
+         # (assign, "$current_mercs", "pt_company_kwarezmian_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_kwarezmian, 1),
          (str_store_string, s20, "@Kwarezmians"),
-         (assign, "$current_mercs", "pt_company_kwarezmian_2"),    
+         # (assign, "$current_mercs", "pt_company_kwarezmian_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_kwarezmian, 1),
          (str_store_string, s20, "@Kwarezmians"),
-         (assign, "$current_mercs", "pt_company_kwarezmian_3"),    
+         # (assign, "$current_mercs", "pt_company_kwarezmian_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
          
@@ -25138,17 +25474,17 @@ game_menus = [ #
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_minor_mongol, 1),
          (str_store_string, s20, "@Mongols"),
-         (assign, "$current_mercs", "pt_company_mongol_1"),    
+         # (assign, "$current_mercs", "pt_company_mongol_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_large_mongol, 1),
          (str_store_string, s20, "@Mongols"),
-         (assign, "$current_mercs", "pt_company_mongol_2"),    
+         # (assign, "$current_mercs", "pt_company_mongol_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_camp_major_mongol, 1),
          (str_store_string, s20, "@Mongols"),
-         (assign, "$current_mercs", "pt_company_mongol_3"),    
+         # (assign, "$current_mercs", "pt_company_mongol_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
 ############################################
     (try_end),
@@ -25170,6 +25506,125 @@ game_menus = [ #
         
           (val_sub, ":mercs_number", 1),
           (party_set_slot, "$current_town", slot_spec_mercs1_number, ":mercs_number"),
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (eq, s20, "@Genoese crossbowmen"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_minor_genoese, 1),
+         (assign, "$current_mercs", "pt_company_genoese_1"),
+       (else_try),
+         (eq, s20, "@Genoese crossbowmen"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_major_genoese, 1),
+         (assign, "$current_mercs", "pt_company_genoese_2"),
+       (else_try),
+         (eq, s20, "@Genoese crossbowmen"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_hq_genoese, 1),
+         (assign, "$current_mercs", "pt_company_genoese_3"),
+       (else_try),
+         (eq, s20, "@Turkopoles"),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_minor_crusader_turcopole, 1),
+         (assign, "$current_mercs", "pt_company_turkopoles_1"),
+       (else_try),
+         (eq, s20, "@Turkopoles"),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_large_crusader_turcopole, 1),
+         (assign, "$current_mercs", "pt_company_turkopoles_2"),
+       (else_try),
+         (eq, s20, "@Turkopoles"),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_major_crusader_turcopole, 1),
+         (assign, "$current_mercs", "pt_company_turkopoles_3"),
+       (else_try),
+         (eq, s20, "@Georgians"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_georgian, 1),
+         (assign, "$current_mercs", "pt_company_georgian_1"),
+       (else_try),
+         (eq, s20, "@Georgians"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_georgian, 1),
+         (assign, "$current_mercs", "pt_company_georgian_2"),
+       (else_try),
+         (eq, s20, "@Georgians"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_georgian, 1),
+         (assign, "$current_mercs", "pt_company_georgian_3"),
+       (else_try),
+         (eq, s20, "@Cumans"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_cuman, 1),
+         (assign, "$current_mercs", "pt_company_cuman_1"),
+       (else_try),
+         (eq, s20, "@Cumans"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_cuman, 1),
+         (assign, "$current_mercs", "pt_company_cuman_2"),
+       (else_try),
+         (eq, s20, "@Cumans"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_cuman, 1),
+         (assign, "$current_mercs", "pt_company_cuman_3"),
+       (else_try),
+         (eq, s20, "@Brabantines"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_minor_brabantine, 1),
+         (assign, "$current_mercs", "pt_company_brabantine_1"),
+       (else_try),
+         (eq, s20, "@Brabantines"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_major_brabantine, 1),
+         (assign, "$current_mercs", "pt_company_brabantine_2"),
+       (else_try),
+         (eq, s20, "@Brabantines"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_hq_brabantine, 1),
+         (assign, "$current_mercs", "pt_company_brabantine_3"),
+       (else_try),
+         (eq, s20, "@Sicily Muslims"),
+         (party_slot_eq, "$current_town", slot_spec_mercs1, merc_sicily_muslims),
+         (assign, "$current_mercs", "pt_company_sicily"),
+       (else_try),
+         (eq, s20, "@Welsh archers"),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_minor_welsh_kern, 1),
+         (assign, "$current_mercs", "pt_company_welsh_1"),
+       (else_try),
+         (eq, s20, "@Welsh archers"),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_large_welsh_kern, 1),
+         (assign, "$current_mercs", "pt_company_welsh_2"),
+       (else_try),
+         (eq, s20, "@Welsh archers"),
+         (party_slot_eq, "$current_town", slot_center_has_outpost_major_welsh_kern, 1),
+         (assign, "$current_mercs", "pt_company_welsh_3"),
+       (else_try),
+         (eq, s20, "@Kipchaks"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_kipchak, 1),
+         (assign, "$current_mercs", "pt_company_kipchak_1"),
+       (else_try),
+         (eq, s20, "@Kipchaks"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_kipchak, 1),
+         (assign, "$current_mercs", "pt_company_kipchak_2"),
+       (else_try),
+         (eq, s20, "@Kipchaks"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_kipchak, 1),
+         (assign, "$current_mercs", "pt_company_kipchak_3"),
+       (else_try),
+         (eq, s20, "@Mordovians"),
+         (party_slot_eq, "$current_town", slot_spec_mercs1, merc_mordovian),
+         (assign, "$current_mercs", "pt_company_mordovian"),
+       (else_try),
+         (eq, s20, "@Kwarezmians"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_kwarezmian, 1),
+         (assign, "$current_mercs", "pt_company_kwarezmian_1"),
+       (else_try),
+         (eq, s20, "@Kwarezmians"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_kwarezmian, 1),
+         (assign, "$current_mercs", "pt_company_kwarezmian_2"),
+       (else_try),
+         (eq, s20, "@Kwarezmians"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_kwarezmian, 1),
+         (assign, "$current_mercs", "pt_company_kwarezmian_3"),
+       (else_try),
+         (eq, s20, "@Mongols"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_minor_mongol, 1),
+         (assign, "$current_mercs", "pt_company_mongol_1"),
+       (else_try),
+         (eq, s20, "@Mongols"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_large_mongol, 1),
+         (assign, "$current_mercs", "pt_company_mongol_2"),
+       (else_try),
+         (eq, s20, "@Mongols"),
+         (party_slot_eq, "$current_town", slot_center_has_camp_major_mongol, 1),
+         (assign, "$current_mercs", "pt_company_mongol_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
           (call_script, "script_fill_company_new", "$current_town", "$current_town", "$current_mercs"),
         (try_end),
      ]),
@@ -25185,22 +25640,22 @@ game_menus = [ #
        (try_begin),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_templar, 1),
          (str_store_string, s21, "@The Knights Templar"),
-         (assign, "$current_mercs", "pt_company_templar_1"),    
+         # (assign, "$current_mercs", "pt_company_templar_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_templar, 1),
          (str_store_string, s21, "@The Knights Templar"),
-         (assign, "$current_mercs", "pt_company_templar_2"),    
+         # (assign, "$current_mercs", "pt_company_templar_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_templar, 1),
          (str_store_string, s21, "@The Knights Templar"),
-         (assign, "$current_mercs", "pt_company_templar_3"),    
+         # (assign, "$current_mercs", "pt_company_templar_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_templar, 1),
          (str_store_string, s21, "@The Knights Templar"),
-         (assign, "$current_mercs", "pt_company_templar_4"),    
+         # (assign, "$current_mercs", "pt_company_templar_4"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
          
@@ -25208,112 +25663,112 @@ game_menus = [ #
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_hospitaller, 1),
          (str_store_string, s21, "@The Knights Hospitalier"),
-         (assign, "$current_mercs", "pt_company_hospitaller_1"),    
+         # (assign, "$current_mercs", "pt_company_hospitaller_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hospitaller, 1),
          (str_store_string, s21, "@The Knights Hospitalier"),
-         (assign, "$current_mercs", "pt_company_hospitaller_2"),    
+         # (assign, "$current_mercs", "pt_company_hospitaller_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_hospitaller, 1),
          (str_store_string, s21, "@The Knights Hospitalier"),
-         (assign, "$current_mercs", "pt_company_hospitaller_3"),    
+         # (assign, "$current_mercs", "pt_company_hospitaller_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_hospitaller, 1),
          (str_store_string, s21, "@The Knights Hospitalier"),
-         (assign, "$current_mercs", "pt_company_hospitaller_4"),    
+         # (assign, "$current_mercs", "pt_company_hospitaller_4"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_saint_lazarus, 1),
          (str_store_string, s21, "@The Knights of Saint Lazarus"),
-         (assign, "$current_mercs", "pt_company_saint_lazarus_1"),    
+         # (assign, "$current_mercs", "pt_company_saint_lazarus_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_saint_lazarus, 1),
          (str_store_string, s21, "@The Knights of Saint Lazarus"),
-         (assign, "$current_mercs", "pt_company_saint_lazarus_2"),    
+         # (assign, "$current_mercs", "pt_company_saint_lazarus_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_saint_lazarus, 1),
          (str_store_string, s21, "@The Knights of Saint Lazarus"),
-         (assign, "$current_mercs", "pt_company_saint_lazarus_3"),    
+         # (assign, "$current_mercs", "pt_company_saint_lazarus_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_santiago, 1),
          (str_store_string, s21, "@The Knights of Santiago"),
-         (assign, "$current_mercs", "pt_company_santiago_1"),    
+         # (assign, "$current_mercs", "pt_company_santiago_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_santiago, 1),
          (str_store_string, s21, "@The Knights of Santiago"),
-         (assign, "$current_mercs", "pt_company_santiago_2"),    
+         # (assign, "$current_mercs", "pt_company_santiago_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_santiago, 1),
          (str_store_string, s21, "@The Knights of Santiago"),
-         (assign, "$current_mercs", "pt_company_santiago_3"),    
+         # (assign, "$current_mercs", "pt_company_santiago_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_calatrava, 1),
          (str_store_string, s21, "@The Knights of Calatrava"),
-         (assign, "$current_mercs", "pt_company_calatrava_1"),    
+         # (assign, "$current_mercs", "pt_company_calatrava_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_calatrava, 1),
          (str_store_string, s21, "@The Knights of Calatrava"),
-         (assign, "$current_mercs", "pt_company_calatrava_2"),    
+         # (assign, "$current_mercs", "pt_company_calatrava_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_calatrava, 1),
          (str_store_string, s21, "@The Knights of Calatrava"),
-         (assign, "$current_mercs", "pt_company_calatrava_3"),    
+         # (assign, "$current_mercs", "pt_company_calatrava_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_saint_thomas, 1),
          (str_store_string, s21, "@The Knights of Saint Thomas of Acre"),
-         (assign, "$current_mercs", "pt_company_saint_thomas_1"),    
+         # (assign, "$current_mercs", "pt_company_saint_thomas_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_saint_thomas, 1),
          (str_store_string, s21, "@The Knights of Saint Thomas of Acre"),
-         (assign, "$current_mercs", "pt_company_saint_thomas_2"),    
+         # (assign, "$current_mercs", "pt_company_saint_thomas_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_saint_thomas, 1),
          (str_store_string, s21, "@The Knights of Saint Thomas of Acre"),
-         (assign, "$current_mercs", "pt_company_saint_thomas_3"),    
+         # (assign, "$current_mercs", "pt_company_saint_thomas_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
 ############################################
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_minor_teutonic, 1),
          (str_store_string, s21, "@The Teutonic Knights"),
-         (assign, "$current_mercs", "pt_company_teutonic_1"),    
+         # (assign, "$current_mercs", "pt_company_teutonic_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_teutonic, 1),
          (str_store_string, s21, "@The Teutonic Knights"),
-         (assign, "$current_mercs", "pt_company_teutonic_2"),    
+         # (assign, "$current_mercs", "pt_company_teutonic_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_hq_teutonic, 1),
          (str_store_string, s21, "@The Teutonic Knights"),
-         (assign, "$current_mercs", "pt_company_teutonic_3"),    
+         # (assign, "$current_mercs", "pt_company_teutonic_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_teutonic, 1),
          (str_store_string, s21, "@The Teutonic Knights"),
-         (assign, "$current_mercs", "pt_company_teutonic_4"),    
+         # (assign, "$current_mercs", "pt_company_teutonic_4"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
          
@@ -25321,12 +25776,12 @@ game_menus = [ #
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_major_varangian, 1),
          (str_store_string, s21, "@The Varangians"),
-         (assign, "$current_mercs", "pt_company_varangian_1"),    
+         # (assign, "$current_mercs", "pt_company_varangian_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_hq_varangian, 1),
          (str_store_string, s21, "@The Varangians"),
-         (assign, "$current_mercs", "pt_company_varangian_2"),    
+         # (assign, "$current_mercs", "pt_company_varangian_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
          
          
@@ -25334,17 +25789,17 @@ game_menus = [ #
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_minor_mamluk, 1),
          (str_store_string, s21, "@The Mamlukes"),
-         (assign, "$current_mercs", "pt_company_mamlukes_1"),   
+         # (assign, "$current_mercs", "pt_company_mamlukes_1"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_major_mamluk, 1),
          (str_store_string, s21, "@The Mamlukes"),
-         (assign, "$current_mercs", "pt_company_mamlukes_2"),   
+         # (assign, "$current_mercs", "pt_company_mamlukes_2"),####### NEW v3.0-KOMKE mercs assigned in consequences block
          
        (else_try),
          (party_slot_eq, "$current_town", slot_center_has_quarters_hq_mamluk, 1),
          (str_store_string, s21, "@The Mamlukes"),
-         (assign, "$current_mercs", "pt_company_mamlukes_3"),
+         # (assign, "$current_mercs", "pt_company_mamlukes_3"),####### NEW v3.0-KOMKE mercs assigned in consequences block
        (try_end),
 ############################################
      ], "Hire {s21} to the town garrison, cost: {reg7}",
@@ -25365,6 +25820,125 @@ game_menus = [ #
         
           (val_sub, ":mercs_number", 1),
           (party_set_slot, "$current_town", slot_spec_mercs2_number, ":mercs_number"),
+####### NEW v3.0-KOMKE START-mercs assigned in consequences block
+       (try_begin),
+         (eq, s21, "@The Knights Templar"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_1"),
+       (else_try),
+         (eq, s21, "@The Knights Templar"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_2"),
+       (else_try),
+         (eq, s21, "@The Knights Templar"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_3"),
+       (else_try),
+         (eq, s21, "@The Knights Templar"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_templar, 1),
+         (assign, "$current_mercs", "pt_company_templar_4"),
+       (else_try),
+         (eq, s21, "@The Knights Hospitalier"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_1"),
+       (else_try),
+         (eq, s21, "@The Knights Hospitalier"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_2"),
+       (else_try),
+         (eq, s21, "@The Knights Hospitalier"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_3"),
+       (else_try),
+         (eq, s21, "@The Knights Hospitalier"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_hospitaller, 1),
+         (assign, "$current_mercs", "pt_company_hospitaller_4"),
+       (else_try),
+         (eq, s21, "@The Knights of Saint Lazarus"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_saint_lazarus, 1),
+         (assign, "$current_mercs", "pt_company_saint_lazarus_1"),
+       (else_try),
+         (eq, s21, "@The Knights of Saint Lazarus"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_saint_lazarus, 1),
+         (assign, "$current_mercs", "pt_company_saint_lazarus_2"),
+       (else_try),
+         (eq, s21, "@The Knights of Saint Lazarus"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_saint_lazarus, 1),
+         (assign, "$current_mercs", "pt_company_saint_lazarus_3"),
+       (else_try),
+         (eq, s21, "@The Knights of Santiago"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_santiago, 1),
+         (assign, "$current_mercs", "pt_company_santiago_1"),
+       (else_try),
+         (eq, s21, "@The Knights of Santiago"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_santiago, 1),
+         (assign, "$current_mercs", "pt_company_santiago_2"),
+       (else_try),
+         (eq, s21, "@The Knights of Santiago"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_santiago, 1),
+         (assign, "$current_mercs", "pt_company_santiago_3"),
+       (else_try),
+         (eq, s21, "@The Knights of Calatrava"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_calatrava, 1),
+         (assign, "$current_mercs", "pt_company_calatrava_1"),
+       (else_try),
+         (eq, s21, "@The Knights of Calatrava"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_calatrava, 1),
+         (assign, "$current_mercs", "pt_company_calatrava_2"),
+       (else_try),
+         (eq, s21, "@The Knights of Calatrava"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_calatrava, 1),
+         (assign, "$current_mercs", "pt_company_calatrava_3"),
+       (else_try),
+         (eq, s21, "@The Knights of Saint Thomas of Acre"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_saint_thomas, 1),
+         (assign, "$current_mercs", "pt_company_saint_thomas_1"),
+       (else_try),
+         (eq, s21, "@The Knights of Saint Thomas of Acre"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_saint_thomas, 1),
+         (assign, "$current_mercs", "pt_company_saint_thomas_2"),
+       (else_try),
+         (eq, s21, "@The Knights of Saint Thomas of Acre"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_saint_thomas, 1),
+         (assign, "$current_mercs", "pt_company_saint_thomas_3"),
+       (else_try),
+         (eq, s21, "@The Teutonic Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_minor_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_1"),
+       (else_try),
+         (eq, s21, "@The Teutonic Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_2"),
+       (else_try),
+         (eq, s21, "@The Teutonic Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_hq_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_3"),
+       (else_try),
+         (eq, s21, "@The Teutonic Knights"),
+         (party_slot_eq, "$current_town", slot_center_has_chapter_major_hq_teutonic, 1),
+         (assign, "$current_mercs", "pt_company_teutonic_4"),
+       (else_try),
+         (eq, s21, "@The Varangians"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_major_varangian, 1),
+         (assign, "$current_mercs", "pt_company_varangian_1"),
+       (else_try),
+         (eq, s21, "@The Varangians"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_hq_varangian, 1),
+         (assign, "$current_mercs", "pt_company_varangian_2"),
+       (else_try),
+         (eq, s21, "@The Mamlukes"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_minor_mamluk, 1),
+         (assign, "$current_mercs", "pt_company_mamlukes_1"),
+       (else_try),
+         (eq, s21, "@The Mamlukes"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_major_mamluk, 1),
+         (assign, "$current_mercs", "pt_company_mamlukes_2"),
+       (else_try),
+         (eq, s21, "@The Mamlukes"),
+         (party_slot_eq, "$current_town", slot_center_has_quarters_hq_mamluk, 1),
+         (assign, "$current_mercs", "pt_company_mamlukes_3"),
+       (try_end),
+####### NEW v3.0-KOMKE END- 
           (call_script, "script_fill_company_new", "$current_town", "$current_town", "$current_mercs"),
         (try_end),
      ]),


### PR DESCRIPTION
.- When there are more than one mercenaries in a town the second one overwrites the first because the global current_mercs is assigned inside menu conditions. Moved the assignment to menu consequences block.