### PR TITLE
 Minister and enter court reworked

### DIFF
--- a/Module/module_dialogs.py
+++ b/Module/module_dialogs.py
@@ -4263,10 +4263,11 @@ dialogs = [
                     (neg|troop_slot_eq, "trp_player", slot_troop_spouse, "$g_talk_troop")],
 "I am at your service, {sire/my lady}", "minister_issues",[]],
 
-[anyone, "start", [(eq, "$g_talk_troop", "trp_temporary_minister"),
-                    (neq, "$g_talk_troop", "$g_player_minister")],
-"It has been an honor to serve you, {sire/my lady}", "close_window",[]],
-
+####### NEW v3.1-KOMKE START-disabled
+# [anyone, "start", [(eq, "$g_talk_troop", "trp_temporary_minister"),
+#                     (neq, "$g_talk_troop", "$g_player_minister")],
+# "It has been an honor to serve you, {sire/my lady}", "close_window",[]],
+####### NEW v3.1-KOMKE END- 
 
 [anyone, "start", [(troop_slot_eq, "$g_talk_troop", slot_troop_occupation, slto_player_companion),
                     (party_slot_eq, "$g_encountered_party", slot_party_type, spt_castle),
@@ -4626,50 +4627,51 @@ dialogs = [
 [anyone|plyr, "member_question_2", [(eq,0,1),
   ], "Do you have any connections that we could use to our advantage?", "member_intelgathering_1",[]],
 
-  
+####### NEW v3.1-KOMKE START-disabled
 ############ NEW v2.7 - player can ask companion directly to become minister
-[anyone|plyr, "member_question_2", 
-[
-### first see if player faction is active and there's a court
-(faction_slot_eq, "fac_player_supporters_faction", slot_faction_state, sfs_active),
-(is_between, "$g_player_court", walled_centers_begin, walled_centers_end),
-### make sure that no companion minister already exists
-(neg|is_between, "$g_player_minister", companions_begin, companions_end)
-], "Would you like to become my minister and help me administer this realm?", "member_minister_1",
-[
-]],
-
-[anyone, "member_minister_1", 
-[
-], "I would be honored. Are you sure about this?", "member_minister_2",
-[
-]],
-
-[anyone|plyr, "member_minister_2", 
-[
-], "Yes. I want you to be my minister.", "member_minister_3",
-[
-(assign, "$g_player_minister", "$g_talk_troop"),
-]],
-
-[anyone|plyr, "member_minister_2", 
-[
-], "Wait. I need to think more about this.", "do_member_trade",
-[
-]],
-
-[anyone, "member_minister_3", 
-[
-], "Very well. I shall move to your court as soon as possible.", "close_window",
-[
-(str_store_troop_name, s1, "$g_talk_troop"),
-(str_store_party_name, s2, "$g_player_court"),
-(display_message, "@{s1} is your new minister and can be found in your court in {s2}."),
-(try_begin),
-  (main_party_has_troop, "$g_talk_troop"),
-  (remove_member_from_party, "$g_talk_troop", "p_main_party"),
-(try_end),
-]],
+# [anyone|plyr, "member_question_2", 
+# [
+# ### first see if player faction is active and there's a court
+# (faction_slot_eq, "fac_player_supporters_faction", slot_faction_state, sfs_active),
+# (is_between, "$g_player_court", walled_centers_begin, walled_centers_end),
+# ### make sure that no companion minister already exists
+# (neg|is_between, "$g_player_minister", companions_begin, companions_end)
+# ], "Would you like to become my minister and help me administer this realm?", "member_minister_1",
+# [
+# ]],
+# 
+# [anyone, "member_minister_1", 
+# [
+# ], "I would be honored. Are you sure about this?", "member_minister_2",
+# [
+# ]],
+# 
+# [anyone|plyr, "member_minister_2", 
+# [
+# ], "Yes. I want you to be my minister.", "member_minister_3",
+# [
+# (assign, "$g_player_minister", "$g_talk_troop"),
+# ]],
+# 
+# [anyone|plyr, "member_minister_2", 
+# [
+# ], "Wait. I need to think more about this.", "do_member_trade",
+# [
+# ]],
+# 
+# [anyone, "member_minister_3", 
+# [
+# ], "Very well. I shall move to your court as soon as possible.", "close_window",
+# [
+# (str_store_troop_name, s1, "$g_talk_troop"),
+# (str_store_party_name, s2, "$g_player_court"),
+# (display_message, "@{s1} is your new minister and can be found in your court in {s2}."),
+# (try_begin),
+#   (main_party_has_troop, "$g_talk_troop"),
+#   (remove_member_from_party, "$g_talk_troop", "p_main_party"),
+# (try_end),
+# ]],
+####### NEW v3.1-KOMKE END- 
 ############
   
   
@@ -6718,11 +6720,13 @@ dialogs = [
    ],
 "{s1} currently does not have a lord. You may wish to keep it this way, as lords will sometimes gravitate towards lieges who have land to offer, but for the time being, no one is collecting any of its rents.", "minister_talk", []],
    
-   [anyone, "minister_issues",
-   [
-   (neg|is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
-   ],
-"At this point, there are no particularly urgent matters which need your attention. I should point out though, sire, that I am not very skilled in the ways of politics, and that I am anxious to return to private life. If you wish to issue any but the most basic directives, I suggest appointing a trusted companion in my stead. In the meantime, is there anything you wish done?", "minister_talk",[]],
+####### NEW v3.1-KOMKE START-disabled
+#    [anyone, "minister_issues",
+#    [
+#    (neg|is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
+#    ],
+# "At this point, there are no particularly urgent matters which need your attention. I should point out though, sire, that I am not very skilled in the ways of politics, and that I am anxious to return to private life. If you wish to issue any but the most basic directives, I suggest appointing a trusted companion in my stead. In the meantime, is there anything you wish done?", "minister_talk",[]],
+####### NEW v3.1-KOMKE END- 
 
    [anyone, "minister_issues",
    [
@@ -6746,7 +6750,7 @@ dialogs = [
    
 [anyone|plyr, "minister_talk",
    [
-   (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
+   # (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),####### NEW v3.1-KOMKE
    ],
 "Do you have any ideas to strengthen our kingdom's unity?", "combined_political_quests",[
    (call_script, "script_get_political_quest", "$g_talk_troop"),
@@ -6827,13 +6831,13 @@ dialogs = [
    
    [anyone|plyr, "minister_talk",
    [
-   (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
+   # (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),####### NEW v3.1-KOMKE
    ],
 "I wish to dispatch an emissary.", "minister_diplomatic_kingdoms", []],
 
    [anyone|plyr, "minister_talk",
    [
-   (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
+   # (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),####### NEW v3.1-KOMKE
    ],
 "I wish to indict a disloyal vassal for treason.", "minister_indict", []],   
 
@@ -6875,32 +6879,33 @@ dialogs = [
 "You have just made such an appointment, {sire/my lady}. If you countermand your decree so soon, there will be great confusion. We will need to wait a few days.", "minister_pretalk", []],
 
    
-   [anyone|plyr, "minister_talk",
-   [
-   (neg|is_between, "$g_player_minister", active_npcs_begin, active_npcs_end),
-   ],
-"I wish for you to retire as minister.", "minister_replace", []],
+####### NEW v3.1-KOMKE START-disabled
+#    [anyone|plyr, "minister_talk",
+#    [
+#    (neg|is_between, "$g_player_minister", active_npcs_begin, active_npcs_end),
+#    ],
+# "I wish for you to retire as minister.", "minister_replace", []],
 
+#    [anyone|plyr, "minister_talk",
+#    [
+#    (is_between, "$g_player_minister", active_npcs_begin, active_npcs_end),
+#     (neg|troop_slot_eq, "$g_talk_troop", slot_troop_occupation, slto_kingdom_hero),
+# 
+#    ],
+# "I wish you to rejoin my party.", "minister_replace", []],
+####### NEW v3.1-KOMKE END- 
+   
+   
    [anyone|plyr, "minister_talk",
    [
-   (is_between, "$g_player_minister", active_npcs_begin, active_npcs_end),
-    (neg|troop_slot_eq, "$g_talk_troop", slot_troop_occupation, slto_kingdom_hero),
-   
-   ],
-"I wish you to rejoin my party.", "minister_replace", []],
-
-   
-   
-   [anyone|plyr, "minister_talk",
-   [
-   (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
+   # (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),####### NEW v3.1-KOMKE
    ],
 "I wish to grant a fief to one of my vassals.", "minister_grant_fief", []],
    
 ###################### NEW PLAYER GRANT FIEF TO HIMSELF
    [anyone|plyr, "minister_talk",  ##### NEW v2.3 - disabled
    [
-   (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
+   # (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),####### NEW v3.1-KOMKE END- 
    ],
 "I wish to grant myself a fief.", "minister_grant_self_fief", []],
 
@@ -12781,7 +12786,7 @@ What kind of recruits do you want?", "dplmc_constable_recruit_select",
 #select kingdom religion
    [anyone|plyr, "minister_talk",
    [
-   (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
+   # (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),####### NEW v3.1-KOMKE
    ],
 "I wish to select the kingdom's religion.", "dplmc_minister_kingdom_religion_ask", []],
    
@@ -12878,7 +12883,7 @@ What kind of recruits do you want?", "dplmc_constable_recruit_select",
 ######select kingdom culture
 [anyone|plyr, "minister_talk",
 [
-(is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
+# (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),####### NEW v3.1-KOMKE
 ],
 ##diplomacy start+ add apostrophe
 "I wish to select the kingdom's culture.", "dplmc_chancellor_kingdom_culture_ask",
@@ -13372,7 +13377,7 @@ What kind of recruits do you want?", "dplmc_constable_recruit_select",
 ##spy mission
    [anyone|plyr, "minister_talk",
    [
-   (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),
+   # (is_between, "$g_player_minister", active_npcs_begin, kingdom_ladies_end),####### NEW v3.1-KOMKE
    ],
 "I wish to spy out another kingdom.", "dplmc_minister_spy_kingdoms", []],
 
@@ -14392,71 +14397,72 @@ What kind of recruits do you want?", "dplmc_constable_recruit_select",
    
 [anyone|plyr, "minister_diplomatic_dispatch_confirm",[], "Actually, hold off on that", "minister_pretalk",[]],
 
-[anyone, "minister_replace", [], "Very good. Whom will you appoint in my stead?", "minister_replace_select", []],
-
-[anyone|plyr|repeat_for_troops, "minister_replace_select",
-   [
-   (store_repeat_object, ":troop_no"),
-   (is_between, ":troop_no", companions_begin, companions_end),
-   (main_party_has_troop, ":troop_no"),
-   (troop_slot_eq, ":troop_no", slot_troop_prisoner_of_party, -1),
-   (str_store_troop_name, s4, ":troop_no"),
-   ], "{s4}", "minister_replace_confirm",
-   [
-   (store_repeat_object, "$g_player_minister"),
-   ]],
-
-   [anyone|plyr, "minister_replace_select",
-   [
-   (troop_get_slot, ":spouse", "trp_player", slot_troop_spouse),
-   (gt, ":spouse", 0),
-   (troop_get_type, ":is_female", ":spouse"),
-   (neg|troop_slot_eq, ":spouse", slot_troop_occupation, slto_kingdom_hero),
-   (eq, ":is_female", 1),
-   (str_store_troop_name, s4, ":spouse"),
-   (neq, ":spouse", "$g_talk_troop"),
-   
-   ], "My wife, {s4}.", "minister_replace_confirm", #husband disabled, as he's an active lord
-   [
-   (troop_get_slot, "$g_player_minister", "trp_player", slot_troop_spouse),
-   ]],
-
-[anyone|plyr, "minister_replace_select", [], "Actually, hold off on that.", "minister_pretalk", []],
-
-
-
-   
-[anyone, "minister_replace_confirm",
-   [
-   (troop_slot_eq, "$g_talk_troop", slot_troop_occupation, slto_player_companion),
-   ], "Very good. {s9} is your new minister. I shall make ready to rejoin you.", "close_window",
-   [
-   (str_store_troop_name, s9, "$g_player_minister"),
-   (party_add_members, "p_main_party", "$g_talk_troop", 1), 
-   (assign, "$g_leave_encounter", 1),
-   (try_begin),
-      (main_party_has_troop, "$g_player_minister"),
-      (party_remove_members, "p_main_party", "$g_player_minister", 1), 
-   (try_end),
-   
-   (try_for_range, ":minister_quest", all_quests_begin, all_quests_end),
-    (quest_slot_eq, ":minister_quest", slot_quest_giver_troop, "$g_talk_troop"),
-    (call_script, "script_abort_quest", ":minister_quest", 0),
-   (try_end),
-   ]],
-   
-[anyone, "minister_replace_confirm",
-   [
-   ], "Very good. {s9} is your new minister. It has been an honor to serve you.", "close_window",
-   [
-   (str_store_troop_name, s9, "$g_player_minister"),
-   (try_begin),
-    (main_party_has_troop, "$g_player_minister"),
-    (party_remove_members, "p_main_party", "$g_player_minister", 1), 
-   (try_end),
-   
-   ]],
-   
+####### NEW v3.1-KOMKE START-disabled
+# [anyone, "minister_replace", [], "Very good. Whom will you appoint in my stead?", "minister_replace_select", []],
+# 
+# [anyone|plyr|repeat_for_troops, "minister_replace_select",
+#    [
+#    (store_repeat_object, ":troop_no"),
+#    (is_between, ":troop_no", companions_begin, companions_end),
+#    (main_party_has_troop, ":troop_no"),
+#    (troop_slot_eq, ":troop_no", slot_troop_prisoner_of_party, -1),
+#    (str_store_troop_name, s4, ":troop_no"),
+#    ], "{s4}", "minister_replace_confirm",
+#    [
+#    (store_repeat_object, "$g_player_minister"),
+#    ]],
+# 
+#    [anyone|plyr, "minister_replace_select",
+#    [
+#    (troop_get_slot, ":spouse", "trp_player", slot_troop_spouse),
+#    (gt, ":spouse", 0),
+#    (troop_get_type, ":is_female", ":spouse"),
+#    (neg|troop_slot_eq, ":spouse", slot_troop_occupation, slto_kingdom_hero),
+#    (eq, ":is_female", 1),
+#    (str_store_troop_name, s4, ":spouse"),
+#    (neq, ":spouse", "$g_talk_troop"),
+# 
+#    ], "My wife, {s4}.", "minister_replace_confirm", #husband disabled, as he's an active lord
+#    [
+#    (troop_get_slot, "$g_player_minister", "trp_player", slot_troop_spouse),
+#    ]],
+# 
+# [anyone|plyr, "minister_replace_select", [], "Actually, hold off on that.", "minister_pretalk", []],
+# 
+# 
+# 
+# 
+# [anyone, "minister_replace_confirm",
+#    [
+#    (troop_slot_eq, "$g_talk_troop", slot_troop_occupation, slto_player_companion),
+#    ], "Very good. {s9} is your new minister. I shall make ready to rejoin you.", "close_window",
+#    [
+#    (str_store_troop_name, s9, "$g_player_minister"),
+#    (party_add_members, "p_main_party", "$g_talk_troop", 1), 
+#    (assign, "$g_leave_encounter", 1),
+#    (try_begin),
+#       (main_party_has_troop, "$g_player_minister"),
+#       (party_remove_members, "p_main_party", "$g_player_minister", 1), 
+#    (try_end),
+# 
+#    (try_for_range, ":minister_quest", all_quests_begin, all_quests_end),
+#     (quest_slot_eq, ":minister_quest", slot_quest_giver_troop, "$g_talk_troop"),
+#     (call_script, "script_abort_quest", ":minister_quest", 0),
+#    (try_end),
+#    ]],
+# 
+# [anyone, "minister_replace_confirm",
+#    [
+#    ], "Very good. {s9} is your new minister. It has been an honor to serve you.", "close_window",
+#    [
+#    (str_store_troop_name, s9, "$g_player_minister"),
+#    (try_begin),
+#     (main_party_has_troop, "$g_player_minister"),
+#     (party_remove_members, "p_main_party", "$g_player_minister", 1), 
+#    (try_end),
+# 
+#    ]],
+####### NEW v3.1-KOMKE END- 
 
 
    [anyone, "minister_grant_fief",
@@ -24014,7 +24020,7 @@ What kind of recruits do you want?", "dplmc_constable_recruit_select",
 
 ####### NEW v3.0-KOMKE START-
 
-[anyone|plyr, "lord_talk", [(eq, 1, 1)], "I want to change your culture and equipment.", "lord_change_culture_equipment",[]],##KOMKE set to false when releasing
+[anyone|plyr, "lord_talk", [(eq, 1, 0)], "I want to change your culture and equipment.", "lord_change_culture_equipment",[]],##KOMKE set to false when releasing
 [anyone, "lord_change_culture_equipment",[], "Which culture?", "lord_change_culture_equipment_choose_culture",[]],
 
 [anyone|plyr|repeat_for_factions, "lord_change_culture_equipment_choose_culture",
@@ -24029,7 +24035,8 @@ What kind of recruits do you want?", "dplmc_constable_recruit_select",
 [anyone, "lord_change_culture_equipment_confirm",[], "Do you want me to change my culture and equipment?", "lord_change_culture_equipment_confirm_2",[]],
 
 [anyone|plyr, "lord_change_culture_equipment_confirm_2",
-    [], "Yes do it.", "lord_talk",
+    # [], "Yes do it.", "lord_talk",
+    [], "Yes do it.", "close_window",
     [
     # ((display_log_message, "@calling script", 0xffffff),##Debugging)
     (troop_set_slot, "$g_talk_troop", slot_troop_cur_culture,  "$temp"),
@@ -27370,12 +27377,14 @@ I suppose there are plenty of bounty hunters around to get the job done . . .", 
 "Yes, my husband?", "spouse_talk",[
  ]],
 
-[anyone|plyr, "spouse_talk",
-   [
-   (eq, "$g_player_minister", "$g_talk_troop"),
-   ],
-"As you are my chief minister, I wish to speak to about affairs of state", "minister_issues",[
- ]],
+####### NEW v3.1-KOMKE START-disabled
+# [anyone|plyr, "spouse_talk",
+#    [
+#    (eq, "$g_player_minister", "$g_talk_troop"),
+#    ],
+# "As you are my chief minister, I wish to speak to about affairs of state", "minister_issues",[
+#  ]],
+ ####### NEW v3.1-KOMKE END- 
 
 [anyone|plyr, "spouse_talk", [
     (check_quest_active, "qst_offer_gift"),
@@ -30447,7 +30456,8 @@ I suppose there are plenty of bounty hunters around to get the job done . . .", 
                     ],
 "Your orders, {Lord/Lady}?", "castle_guard_players",[]],
 [anyone|plyr, "castle_guard_players", [],
-"Open the door. I'll go in.", "close_window",[(call_script, "script_enter_court", "$current_town")]],
+# "Open the door. I'll go in.", "close_window",[(call_script, "script_enter_court", "$current_town")]],####### NEW v3.1-KOMKE
+"Open the door. I'll go in.", "close_window",[(jump_to_menu, "mnu_castle_entered")]],####### NEW v3.1-KOMKE
 [anyone|plyr, "castle_guard_players", [],
 "Never mind.", "close_window",[]],
 
@@ -30471,26 +30481,29 @@ I suppose there are plenty of bounty hunters around to get the job done . . .", 
 "Never mind.", "close_window",[]],
 
    [anyone, "castle_guard_intro_2", [
-    (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_state, sfai_feast),
-    (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_object, "$current_town"),
+    # (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_state, sfai_feast),####### NEW v3.1-KOMKE
+    # (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_object, "$current_town"),####### NEW v3.1-KOMKE
 
-    (this_or_next|neq, "$players_kingdom", "$g_encountered_party_faction"),
-        (neg|troop_slot_ge, "trp_player", slot_troop_renown, 50),
-
-    (neg|troop_slot_ge, "trp_player", slot_troop_renown, 125),
+    # (this_or_next|neq, "$players_kingdom", "$g_encountered_party_faction"),####### NEW v3.1-KOMKE
+    (neq, "$players_kingdom", "$g_encountered_party_faction"),####### NEW v3.1-KOMKE
+        # (neg|troop_slot_ge, "trp_player", slot_troop_renown, 50),####### NEW v3.1-KOMKE
+    # (this_or_next|neg|troop_slot_ge, "trp_player", slot_troop_renown,125),####### NEW v3.1-KOMKE
+    (neg|troop_slot_ge, "trp_player", slot_troop_renown,200),####### NEW v3.1-KOMKE
     (neq, "$g_player_eligible_feast_center_no", "$current_town"),
 
-    (neg|check_quest_active, "qst_wed_betrothed"),
-    (neg|check_quest_active, "qst_wed_betrothed_female"),
+    # (neg|check_quest_active, "qst_wed_betrothed"),####### NEW v3.1-KOMKE
+    # (neg|check_quest_active, "qst_wed_betrothed_female"),####### NEW v3.1-KOMKE
 
-    (neg|troop_slot_ge, "trp_player", slot_troop_spouse, 1), #Married players always make the cut
+    # (neg|troop_slot_ge, "trp_player", slot_troop_spouse, 1), #Married players always make the cut####### NEW v3.1-KOMKE
 
-   ], "I'm afraid there is a feast in progress, and you are not invited.", "close_window", []],
+   # ], "I'm afraid there is a feast in progress, and you are not invited.", "close_window", []],####### NEW v3.1-KOMKE
+   ], "I'm afraid your status is too low to enter the castle, but I'm sure we can find accomodation for you in the dungeon if you insist.", "close_window", []],
 
 
    [anyone, "castle_guard_intro_2", [], "You can go in after leaving your weapons with me. No one is allowed to carry arms into the lord's hall.", "castle_guard_intro_3", []],
 
-[anyone|plyr, "castle_guard_intro_3", [], "Here, take my arms. I'll go in.", "close_window", [(call_script, "script_enter_court", "$current_town")]],
+# [anyone|plyr, "castle_guard_intro_3", [], "Here, take my arms. I'll go in.", "close_window", [(call_script, "script_enter_court", "$current_town")]],####### NEW v3.1-KOMKE
+[anyone|plyr, "castle_guard_intro_3", [], "Here, take my arms. I'll go in.", "close_window", [(jump_to_menu, "mnu_castle_entered")]],####### NEW v3.1-KOMKE
 
 [anyone|plyr, "castle_guard_intro_3", [], "No, I give my arms to no one.", "castle_guard_intro_2b", []],
 [anyone, "castle_guard_intro_2b", [], "Then you can't go in.", "close_window", []],
@@ -37843,15 +37856,15 @@ I suppose there are plenty of bountyhunters around to get the job done . . .", "
 ## CC
 [anyone|plyr, "arena_master_melee_talk", [], "Good. That's what I am going to do.", "close_window", 
 [
-  # (store_random_in_range, ":random_entry", 0, 39),
-  # (assign, "$g_player_entry_point", ":random_entry"),
-  (assign, "$g_player_entry_point", 51),
+  (store_random_in_range, ":random_entry", 0, 39),
+  (assign, "$g_player_entry_point", ":random_entry"),
+# (assign, "$g_player_entry_point", 51),
 # (try_end),
   (assign, "$last_training_fight_town", "$current_town"),
   (store_current_hours, "$training_fight_time"),
   (assign, "$g_mt_mode", abm_training),
-  (party_get_slot, ":scene", "$current_town",slot_town_arena), ### NEW v2.1 - normal battle
-  # (assign, ":scene", "scn_random_scene"),
+  # (party_get_slot, ":scene", "$current_town",slot_town_arena), ### NEW v2.1 - normal battle
+  (assign, ":scene", "scn_random_scene"),
   (modify_visitors_at_site, ":scene"),
   (reset_visitors),
   (set_visitor, "$g_player_entry_point", "trp_player"),
@@ -39366,12 +39379,39 @@ I suppose there are plenty of bountyhunters around to get the job done . . .", "
                     (party_slot_eq, "$current_town",slot_town_lord, "trp_player"),
                      ], "Your orders, {my lord/my lady}?", "hall_guard_talk",[]],
 
+####### NEW v3.1-KOMKE START-
 [anyone, "start", [(eq, "$talk_context", tc_court_talk),
                     (this_or_next|is_between, "$g_talk_troop",regular_troops_begin, regular_troops_end),
                     (is_between, "$g_talk_troop", "trp_cstm_custom_troop_1_tier_0_0_0", "trp_cstm_custom_troops_end"),
                     (is_between, "$g_encountered_party_faction",kingdoms_begin, kingdoms_end),
-                     ], "We are not supposed to talk while on guard, {sir/madam}.", "close_window",[]],
-
+                     # ], "We are not supposed to talk while on guard, {sir/madam}.", "close_window",[]],
+                     ], "We are not supposed to talk while on guard, {sir/madam}.", "ask_question_guard",[]],
+[anyone|plyr, "ask_question_guard", [], "I want to know the location of someone.", "ask_question_guard_2",[]],
+[anyone|plyr|repeat_for_troops, "ask_question_guard_2", 
+                    [
+                    (store_repeat_object, ":troop_no"),
+                    (is_between, ":troop_no", active_npcs_begin, kingdom_ladies_end),
+                    (troop_slot_eq, ":troop_no", slot_troop_is_alive, 1),  ## he's alive/active
+                    (neq, ":troop_no", "trp_player"),
+                    (this_or_next|troop_slot_eq, ":troop_no", slot_troop_occupation, slto_kingdom_hero),
+                    (troop_slot_eq, ":troop_no", slot_troop_occupation, slto_kingdom_lady),
+                    (store_troop_faction, ":hero_faction", ":troop_no"),
+                    (store_faction_of_party, ":center_faction", "$current_town"),
+                    (eq, ":hero_faction", ":center_faction"),
+                    (str_store_troop_name, s1, ":troop_no"),
+                    (try_begin),
+                        (faction_slot_eq, "$players_kingdom", slot_faction_marshall, ":troop_no"),
+                        (str_store_string, s1, "@Our marshal, {s1}"),
+                    (try_end),
+                    ],
+"{s1}", "ask_question_guard_3",[(store_repeat_object, "$hero_requested_to_learn_location")]],
+[anyone, "ask_question_guard_3",
+   [
+   (call_script, "script_update_troop_location_notes", "$hero_requested_to_learn_location", 1),
+   (call_script, "script_get_information_about_troops_position", "$hero_requested_to_learn_location", 0),
+   ],
+"{s1}", "close_window",[]],
+####### NEW v3.1-KOMKE END- 
 [anyone|plyr, "hall_guard_talk", [], "Stay on duty and let me know if anyone comes to see me.", "hall_guard_duty",[]],
 [anyone, "hall_guard_duty", [], "Yes, {my lord/my lady}. As you wish.", "close_window",[]],
 

--- a/Module/module_game_menus.py
+++ b/Module/module_game_menus.py
@@ -14246,23 +14246,26 @@ game_menus = [ #
              (eq, "$sneaked_into_town", 1),
              (display_message, "str_door_locked",0xFFFFAAAA),
            (else_try),
-             (this_or_next|neq, "$players_kingdom", "$g_encountered_party_faction"),
-                (neg|troop_slot_ge, "trp_player", slot_troop_renown, 50),
-             (neg|troop_slot_ge, "trp_player", slot_troop_renown, 125),
+             # (this_or_next|neq, "$players_kingdom", "$g_encountered_party_faction"),####### NEW v3.1-KOMKE
+             (neq, "$players_kingdom", "$g_encountered_party_faction"),####### NEW v3.1-KOMKE
+                # (neg|troop_slot_ge, "trp_player", slot_troop_renown, 50),####### NEW v3.1-KOMKE
+             # (neg|troop_slot_ge, "trp_player", slot_troop_renown, 125),####### NEW v3.1-KOMKE
+             (neg|troop_slot_ge, "trp_player", slot_troop_renown, 200),####### NEW v3.1-KOMKE
              (neq, "$g_player_eligible_feast_center_no", "$current_town"),
 
-             (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_state, sfai_feast),
-             (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_object, "$g_encountered_party"),
+             # (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_state, sfai_feast),####### NEW v3.1-KOMKE
+             # (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_object, "$g_encountered_party"),####### NEW v3.1-KOMKE
 
-             (neg|check_quest_active, "qst_wed_betrothed"),
-             (neg|check_quest_active, "qst_wed_betrothed_female"),
+             # (neg|check_quest_active, "qst_wed_betrothed"),####### NEW v3.1-KOMKE
+             # (neg|check_quest_active, "qst_wed_betrothed_female"),####### NEW v3.1-KOMKE
 
-             (neg|troop_slot_ge, "trp_player", slot_troop_spouse, active_npcs_begin), #Married players always make the cut
+             # (neg|troop_slot_ge, "trp_player", slot_troop_spouse, active_npcs_begin), #Married players always make the cut####### NEW v3.1-KOMKE
 
              (jump_to_menu, "mnu_cannot_enter_court"),
            (else_try),
              (assign, "$town_entered", 1),
-             (call_script, "script_enter_court", "$current_town"),
+             # (call_script, "script_enter_court", "$current_town"),####### NEW v3.1-KOMKE
+             (jump_to_menu, "mnu_castle_entered"),####### NEW v3.1-KOMKE
            (try_end),
         ], "Door to the castle."),
 
@@ -14304,23 +14307,26 @@ game_menus = [ #
              (eq, "$sneaked_into_town", 1),
              (display_message, "str_door_locked",0xFFFFAAAA),
            (else_try),
-             (this_or_next|neq, "$players_kingdom", "$g_encountered_party_faction"),
-                (neg|troop_slot_ge, "trp_player", slot_troop_renown, 50),
-             (neg|troop_slot_ge, "trp_player", slot_troop_renown, 125),
-             (neq, "$g_player_eligible_feast_center_no", "$current_town"),
+             # (this_or_next|neq, "$players_kingdom", "$g_encountered_party_faction"),####### NEW v3.1-KOMKE
+             (neq, "$players_kingdom", "$g_encountered_party_faction"),####### NEW v3.1-KOMKE
+                # (neg|troop_slot_ge, "trp_player", slot_troop_renown, 50),####### NEW v3.1-KOMKE
+             # (this_or_next|neg|troop_slot_ge, "trp_player", slot_troop_renown, 125),####### NEW v3.1-KOMKE
+             (neg|troop_slot_ge, "trp_player", slot_troop_renown, 200),####### NEW v3.1-KOMKE
+             (neq, "$g_player_eligible_feast_center_no", "$current_town"),####### NEW v3.1-KOMKE
 
-             (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_state, sfai_feast),
-             (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_object, "$g_encountered_party"),
+             # (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_state, sfai_feast),####### NEW v3.1-KOMKE
+             # (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_object, "$g_encountered_party"),####### NEW v3.1-KOMKE
 
-             (neg|check_quest_active, "qst_wed_betrothed"),
-             (neg|check_quest_active, "qst_wed_betrothed_female"),
+             # (neg|check_quest_active, "qst_wed_betrothed"),####### NEW v3.1-KOMKE
+             # (neg|check_quest_active, "qst_wed_betrothed_female"),####### NEW v3.1-KOMKE
 
-             (neg|troop_slot_ge, "trp_player", slot_troop_spouse, active_npcs_begin), #Married players always make the cut
+             # (neg|troop_slot_ge, "trp_player", slot_troop_spouse, active_npcs_begin), #Married players always make the cut####### NEW v3.1-KOMKE
 
              (jump_to_menu, "mnu_cannot_enter_court"),
             (else_try),
              (assign, "$town_entered", 1),
-             (call_script, "script_enter_court", "$current_town"),
+             # (call_script, "script_enter_court", "$current_town"),####### NEW v3.1-KOMKE
+             (jump_to_menu, "mnu_castle_entered"),####### NEW v3.1-KOMKE
            (try_end),
         ], "Door to the castle."),
 
@@ -15425,7 +15431,8 @@ game_menus = [ #
 
 
    ("cannot_enter_court",0,
-    "There is a feast in progress in the lord's hall, but you are not of sufficient status to be invited inside. Perhaps increasing your renown would win you admittance -- or you might also try distinguishing yourself at a tournament while the feast is in progress...",
+    # "There is a feast in progress in the lord's hall, but you are not of sufficient status to be invited inside. Perhaps increasing your renown would win you admittance -- or you might also try distinguishing yourself at a tournament while the feast is in progress...",####### NEW v3.1-KOMKE
+    "You are not of sufficient status to be invited inside. Perhaps increasing your renown would win you admittance -- or you might also try distinguishing yourself at a tournament while a feast is in progress...",####### NEW v3.1-KOMKE
     "none",
     [],
     [
@@ -15537,13 +15544,18 @@ game_menus = [ #
           (str_store_string, s8, "@Moreover, you earn {reg8} denars from the clever bets you placed on yourself..."),
         (try_end),
         (try_begin),
-            (this_or_next|neq, "$players_kingdom", "$g_encountered_party_faction"),
-                (neg|troop_slot_ge, "trp_player", slot_troop_renown, 70),
-            (neg|troop_slot_ge, "trp_player", slot_troop_renown, 145),
-
-            (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_state, sfai_feast),
-            (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_object, "$g_encountered_party"),
+####### NEW v3.1-KOMKE START-
+            # (this_or_next|neq, "$players_kingdom", "$g_encountered_party_faction"),
+            #     (neg|troop_slot_ge, "trp_player", slot_troop_renown, 70),
+            # (neg|troop_slot_ge, "trp_player", slot_troop_renown, 145),
+            # 
+            # (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_state, sfai_feast),
+            # (faction_slot_eq, "$g_encountered_party_faction", slot_faction_ai_object, "$g_encountered_party"),
+            # (str_store_string, s8, "str_s8_you_are_also_invited_to_attend_the_ongoing_feast_in_the_castle"),
+            (neq, "$players_kingdom", "$g_encountered_party_faction"),
+            (assign, "$g_player_eligible_feast_center_no", "$current_town"),
             (str_store_string, s8, "str_s8_you_are_also_invited_to_attend_the_ongoing_feast_in_the_castle"),
+####### NEW v3.1-KOMKE END- 
         (try_end),
         (troop_add_gold, "trp_player", ":total_win"),
         (assign, ":player_odds_sub", 0),
@@ -15903,7 +15915,7 @@ game_menus = [ #
     ("town_tournament_start_new",0,
 ####### NEW v3.0-KOMKE START-
     # "Select which type of tournament do you wish to participate in. You can only participate in one of them.",
-    "You need 200 renown to fight in tournaments. Only companions can join your team!",
+    "You need 125 renown to fight in tournaments. Only companions can join your team!",####### NEW v3.1-KOMKE
     "none",
     [
         #(set_background_mesh, "mesh_pic_tournament_euro"),
@@ -15927,7 +15939,7 @@ game_menus = [ #
           # (display_message, "@You do not have five men in your party to form a team!", 0xEA9999),
         # (try_end),
         (troop_get_slot, ":plyr_renown", "trp_player", slot_troop_renown),
-        (ge, ":plyr_renown", 200),
+        (ge, ":plyr_renown", 125),####### NEW v3.1-KOMKE 200->125 so player can access tournament and enter castle (200 required) if he wins
 ####### NEW v3.0-KOMKE END- 
       ], "Join team on team tournament.",
       [  
@@ -18576,217 +18588,219 @@ game_menus = [ #
 	  #########
       ],
     [
-      ("appoint_spouse",[
-      (troop_slot_ge, "trp_player", slot_troop_spouse, 1),
-      (troop_get_slot, ":player_spouse", "trp_player", slot_troop_spouse),
-      (neg|troop_slot_eq, ":player_spouse", slot_troop_occupation, slto_kingdom_hero),
-      (str_store_troop_name, s10, ":player_spouse"),
-      ], "Appoint your wife, {s10}...",
-       [
-       (troop_get_slot, ":player_spouse", "trp_player", slot_troop_spouse),
-       (assign, "$g_player_minister", ":player_spouse"),
-       (jump_to_menu, "mnu_minister_confirm"),
-       ]),
-
-      ("appoint_npc1",[
-      (main_party_has_troop, "trp_npc1"),
-      (str_store_troop_name, s10, "trp_npc1"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc1"),
-       (jump_to_menu, "mnu_minister_confirm"),
-       ]),
-
-      ("appoint_npc2",[
-      (main_party_has_troop, "trp_npc2"),
-      (str_store_troop_name, s10, "trp_npc2"),], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc2"),
-       (jump_to_menu, "mnu_minister_confirm"),]),
-
-      ("appoint_npc3",[
-      (main_party_has_troop, "trp_npc3"),
-      (str_store_troop_name, s10, "trp_npc3"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc3"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc4",[
-      (main_party_has_troop, "trp_npc4"),
-      (str_store_troop_name, s10, "trp_npc4"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc4"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc5",[
-      (main_party_has_troop, "trp_npc5"),
-      (str_store_troop_name, s10, "trp_npc5"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc5"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc6",[
-      (main_party_has_troop, "trp_npc6"),
-      (str_store_troop_name, s10, "trp_npc6"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc6"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc7",[
-      (main_party_has_troop, "trp_npc7"),
-      (str_store_troop_name, s10, "trp_npc7"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc7"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc8",[
-      (main_party_has_troop, "trp_npc8"),
-      (str_store_troop_name, s10, "trp_npc8"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc8"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc9",[
-      (main_party_has_troop, "trp_npc9"),
-      (str_store_troop_name, s10, "trp_npc9"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc9"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc10",[ #was npc9
-      (main_party_has_troop, "trp_npc10"),
-      (str_store_troop_name, s10, "trp_npc10"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc10"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc11",[
-      (main_party_has_troop, "trp_npc11"),
-      (str_store_troop_name, s10, "trp_npc11"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc11"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc12",[
-      (main_party_has_troop, "trp_npc12"),
-      (str_store_troop_name, s10, "trp_npc12"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc12"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc13",[
-      (main_party_has_troop, "trp_npc13"),
-      (str_store_troop_name, s10, "trp_npc13"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc13"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc14",[
-      (main_party_has_troop, "trp_npc14"),
-      (str_store_troop_name, s10, "trp_npc14"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc14"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc15",[
-      (main_party_has_troop, "trp_npc15"),
-      (str_store_troop_name, s10, "trp_npc15"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc15"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc16",[
-      (main_party_has_troop, "trp_npc16"),
-      (str_store_troop_name, s10, "trp_npc16"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc16"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc17",[
-      (main_party_has_troop, "trp_npc17"),
-      (str_store_troop_name, s10, "trp_npc17"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc17"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc18",[
-      (main_party_has_troop, "trp_npc18"),
-      (str_store_troop_name, s10, "trp_npc18"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc18"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc20",[
-      (main_party_has_troop, "trp_npc20"),
-      (str_store_troop_name, s10, "trp_npc20"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc20"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc21",[
-      (main_party_has_troop, "trp_npc21"),
-      (str_store_troop_name, s10, "trp_npc21"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc21"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-       
-      ("appoint_npc22",[
-      (main_party_has_troop, "trp_npc22"),
-      (str_store_troop_name, s10, "trp_npc22"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc22"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc23",[
-      (main_party_has_troop, "trp_npc23"),
-      (str_store_troop_name, s10, "trp_npc23"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc23"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc24",[
-      (main_party_has_troop, "trp_npc24"),
-      (str_store_troop_name, s10, "trp_npc24"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc24"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc25",[
-      (main_party_has_troop, "trp_npc25"),
-      (str_store_troop_name, s10, "trp_npc25"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc25"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
-
-      ("appoint_npc26",[
-      (main_party_has_troop, "trp_npc26"),
-      (str_store_troop_name, s10, "trp_npc26"),
-      ], "Appoint {s10}",
-       [
-       (assign, "$g_player_minister", "trp_npc26"),
-       (jump_to_menu, "mnu_minister_confirm"), ]),
+####### NEW v3.1-KOMKE START-disabled
+      # ("appoint_spouse",[
+      # (troop_slot_ge, "trp_player", slot_troop_spouse, 1),
+      # (troop_get_slot, ":player_spouse", "trp_player", slot_troop_spouse),
+      # (neg|troop_slot_eq, ":player_spouse", slot_troop_occupation, slto_kingdom_hero),
+      # (str_store_troop_name, s10, ":player_spouse"),
+      # ], "Appoint your wife, {s10}...",
+      #  [
+      #  (troop_get_slot, ":player_spouse", "trp_player", slot_troop_spouse),
+      #  (assign, "$g_player_minister", ":player_spouse"),
+      #  (jump_to_menu, "mnu_minister_confirm"),
+      #  ]),
+      # 
+      # ("appoint_npc1",[
+      # (main_party_has_troop, "trp_npc1"),
+      # (str_store_troop_name, s10, "trp_npc1"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc1"),
+      #  (jump_to_menu, "mnu_minister_confirm"),
+      #  ]),
+      # 
+      # ("appoint_npc2",[
+      # (main_party_has_troop, "trp_npc2"),
+      # (str_store_troop_name, s10, "trp_npc2"),], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc2"),
+      #  (jump_to_menu, "mnu_minister_confirm"),]),
+      # 
+      # ("appoint_npc3",[
+      # (main_party_has_troop, "trp_npc3"),
+      # (str_store_troop_name, s10, "trp_npc3"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc3"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc4",[
+      # (main_party_has_troop, "trp_npc4"),
+      # (str_store_troop_name, s10, "trp_npc4"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc4"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc5",[
+      # (main_party_has_troop, "trp_npc5"),
+      # (str_store_troop_name, s10, "trp_npc5"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc5"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc6",[
+      # (main_party_has_troop, "trp_npc6"),
+      # (str_store_troop_name, s10, "trp_npc6"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc6"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc7",[
+      # (main_party_has_troop, "trp_npc7"),
+      # (str_store_troop_name, s10, "trp_npc7"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc7"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc8",[
+      # (main_party_has_troop, "trp_npc8"),
+      # (str_store_troop_name, s10, "trp_npc8"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc8"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc9",[
+      # (main_party_has_troop, "trp_npc9"),
+      # (str_store_troop_name, s10, "trp_npc9"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc9"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc10",[ #was npc9
+      # (main_party_has_troop, "trp_npc10"),
+      # (str_store_troop_name, s10, "trp_npc10"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc10"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc11",[
+      # (main_party_has_troop, "trp_npc11"),
+      # (str_store_troop_name, s10, "trp_npc11"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc11"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc12",[
+      # (main_party_has_troop, "trp_npc12"),
+      # (str_store_troop_name, s10, "trp_npc12"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc12"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc13",[
+      # (main_party_has_troop, "trp_npc13"),
+      # (str_store_troop_name, s10, "trp_npc13"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc13"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc14",[
+      # (main_party_has_troop, "trp_npc14"),
+      # (str_store_troop_name, s10, "trp_npc14"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc14"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc15",[
+      # (main_party_has_troop, "trp_npc15"),
+      # (str_store_troop_name, s10, "trp_npc15"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc15"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc16",[
+      # (main_party_has_troop, "trp_npc16"),
+      # (str_store_troop_name, s10, "trp_npc16"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc16"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc17",[
+      # (main_party_has_troop, "trp_npc17"),
+      # (str_store_troop_name, s10, "trp_npc17"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc17"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc18",[
+      # (main_party_has_troop, "trp_npc18"),
+      # (str_store_troop_name, s10, "trp_npc18"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc18"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc20",[
+      # (main_party_has_troop, "trp_npc20"),
+      # (str_store_troop_name, s10, "trp_npc20"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc20"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc21",[
+      # (main_party_has_troop, "trp_npc21"),
+      # (str_store_troop_name, s10, "trp_npc21"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc21"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc22",[
+      # (main_party_has_troop, "trp_npc22"),
+      # (str_store_troop_name, s10, "trp_npc22"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc22"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc23",[
+      # (main_party_has_troop, "trp_npc23"),
+      # (str_store_troop_name, s10, "trp_npc23"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc23"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc24",[
+      # (main_party_has_troop, "trp_npc24"),
+      # (str_store_troop_name, s10, "trp_npc24"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc24"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc25",[
+      # (main_party_has_troop, "trp_npc25"),
+      # (str_store_troop_name, s10, "trp_npc25"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc25"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+      # 
+      # ("appoint_npc26",[
+      # (main_party_has_troop, "trp_npc26"),
+      # (str_store_troop_name, s10, "trp_npc26"),
+      # ], "Appoint {s10}",
+      #  [
+      #  (assign, "$g_player_minister", "trp_npc26"),
+      #  (jump_to_menu, "mnu_minister_confirm"), ]),
+####### NEW v3.1-KOMKE END- 
 
       # ("appoint_npc27",[
       # (main_party_has_troop, "trp_npc27"),
@@ -32705,8 +32719,6 @@ game_menus = [ #
 
     [
     
-        
-		
      ("call_retinue", ##TOWN
       [
         (party_get_slot, ":town_lord", "$current_town", slot_town_lord),
@@ -33282,8 +33294,8 @@ game_menus = [ #
     [
       ("camp_mod_1",
 		[],"Increase player's renown.",
-       [(str_store_string, s1, "@Player renown is increased by 100. "),
-        (call_script, "script_change_troop_renown", "trp_player" ,100),
+       [(str_store_string, s1, "@Player renown is increased by 25. "),
+        (call_script, "script_change_troop_renown", "trp_player" ,25),
         # (jump_to_menu, "mnu_camp_modding"),
         ]
        ),
@@ -33881,6 +33893,8 @@ game_menus = [ #
     ]
   ),
 
+######################################################
+
 ####### NEW v3.0-KOMKE START-This will notify the player when a fief improvement is finished
    ("notification_building_constructed",0,
     "Construction of {s0} in {s1} has finished.",
@@ -33897,7 +33911,228 @@ game_menus = [ #
         ]),
      ]
   ),
-####### NEW v3.0-KOMKE END- 
+####### NEW v3.0-KOMKE END-
+  
+######################################################
+  
+####### NEW v3.1-KOMKE START-New menus to separate court, lords and ladies and to allow enough scene positions during tournaments 
+    ("castle_entered",0,
+    "You are allowed to enter the castle, what do you want to do?",
+    "none",
+    [],
+    [
+      ("attend_court",
+        [
+        
+        ], "Attend court",
+        [
+        (assign, ":center_no", "$current_town"),
+        (assign, "$talk_context", tc_court_talk),
+        (set_jump_mission, "mt_visit_town_castle"),
+        (mission_tpl_entry_clear_override_items, "mt_visit_town_castle", 0),
+        #(mission_tpl_entry_set_override_flags, "mt_visit_town_castle", 0, af_override_all),
+        (party_get_slot, ":castle_scene", ":center_no", slot_town_castle),
+        (modify_visitors_at_site, ":castle_scene"),
+        (reset_visitors),
+        
+        #Adding guards
+        (store_faction_of_party, ":center_faction", ":center_no"),
+        # (faction_get_slot, ":guard_troop", ":center_faction", slot_faction_castle_guard_troop), #### bugfix
+        
+        ############# NEW v1.8 - checking center culture instead of faction culture  
+        (party_get_slot, ":center_culture", ":center_no", slot_center_culture),
+        (faction_get_slot, ":guard_troop", ":center_culture", slot_faction_castle_guard_troop), #### bugfix
+        (try_begin),
+          (le, ":guard_troop", 0),
+          (assign, ":guard_troop", "trp_euro_spearman_3"),
+        (try_end),
+        (set_visitor, 6, ":guard_troop"),
+        # (set_visitor, 7, ":guard_troop"),
+        (assign, ":cur_pos", 16),
+
+        (try_begin),
+          (eq, "$g_player_court", ":center_no"),##spouse only if center is player court
+          (troop_get_slot, ":player_spouse", "trp_player", slot_troop_spouse),
+          (gt, ":player_spouse", 0),
+          (troop_slot_eq, ":player_spouse", slot_troop_cur_center, ":center_no"),
+          (set_visitor, ":cur_pos", ":player_spouse"),
+          (val_add, ":cur_pos", 1),
+        (try_end),
+        (try_begin),##KOMKE I have to use leaded party because slot_troop_cur_center does not work for lords ???
+            (party_get_slot, ":center_lord", ":center_no", slot_town_lord),
+            (gt, ":center_lord", 0),##not including player
+            (troop_get_slot, ":center_lord_party", ":center_lord", slot_troop_leaded_party),
+            (party_get_attached_to, ":lord_party_located", ":center_lord_party"),
+            (eq, ":lord_party_located", ":center_no"),
+            (set_visitor, ":cur_pos", ":center_lord"),
+            (val_add, ":cur_pos", 1),
+        (try_end),
+        (try_begin),
+          (troop_get_slot, ":center_lady", ":center_lord", slot_troop_spouse),
+          (gt, ":center_lady", 0),##not including player
+          (troop_slot_eq, ":center_lady", slot_troop_cur_center, ":center_no"),
+          (set_visitor, ":cur_pos", ":center_lady"),
+          (val_add, ":cur_pos", 1),
+        (try_end),
+        (try_begin),
+          (eq, "$g_player_court", ":center_no"),##minister and advisors only if center is player court
+          (gt, "$g_player_minister", 0),
+          (assign, "$g_player_minister", "trp_temporary_minister"),  #fix for wrong troops after update
+          (set_visitor, ":cur_pos", "$g_player_minister"),
+          (val_add, ":cur_pos", 1),
+        (try_end),
+        ##diplomacy begin
+        (try_begin),
+          (eq, "$g_player_court", ":center_no"),##minister and advisors only if center is player court
+          (gt, "$g_player_chamberlain", 0),
+          (assign, "$g_player_chamberlain", "trp_dplmc_chamberlain"),  #fix for wrong troops after update
+          (set_visitor, ":cur_pos", "$g_player_chamberlain"),
+          (val_add, ":cur_pos", 1),
+        (try_end),
+        
+        (try_begin),
+          (eq, "$g_player_court", ":center_no"),##minister and advisors only if center is player court
+          (gt, "$g_player_constable", 0),
+          (assign, "$g_player_constable", "trp_dplmc_constable"),  #fix for wrong troops after update
+          (set_visitor, ":cur_pos", "$g_player_constable"),
+          (val_add, ":cur_pos", 1),
+        (try_end),
+        
+        (try_begin),
+          (eq, "$g_player_court", ":center_no"),##minister and advisors only if center is player court
+          (gt, "$g_player_chancellor", 0),
+          (assign, "$g_player_chancellor", "trp_dplmc_chancellor"), #fix for wrong troops after update
+          (set_visitor, ":cur_pos", "$g_player_chancellor"),
+          (val_add, ":cur_pos", 1),
+        (try_end),
+        ##diplomacy end
+        
+        #Lords wishing to pledge allegiance - inactive, but part of player faction
+        (try_begin),
+          (eq, "$g_player_court", ":center_no"),
+          (faction_slot_eq, ":center_faction", slot_faction_leader, "trp_player"),
+          (try_for_range, ":active_npc", active_npcs_begin, active_npcs_end),
+            (troop_slot_eq, ":active_npc", slot_troop_is_alive, 1),  ## he's alive/active
+            (store_faction_of_troop, ":active_npc_faction", ":active_npc"),
+            (eq, ":active_npc_faction", "fac_player_supporters_faction"),
+            (troop_slot_eq, ":active_npc", slot_troop_occupation, slto_inactive),
+            (neg|troop_slot_ge, ":active_npc", slot_troop_prisoner_of_party, 0), #if he/she is not prisoner in any center.
+            (neq, ":active_npc", "$g_player_minister"),
+            (set_visitor, ":cur_pos", ":active_npc"),
+            (val_add, ":cur_pos", 1),
+          (try_end),
+        (try_end),
+        
+        (set_jump_entry, 0),
+        (jump_to_scene, ":castle_scene"),
+        (scene_set_slot, ":castle_scene", slot_scene_visited, 1),
+        (change_screen_mission),
+        ]),
+      
+      ("talk_to_lords.",
+        [
+        (str_clear, s1),
+        (try_begin),
+          (store_faction_of_party, ":center_faction", "$current_town"),
+          (faction_slot_eq, ":center_faction", slot_faction_ai_state, sfai_feast),
+          (faction_slot_eq, ":center_faction", slot_faction_ai_object, "$current_town"),
+          (str_store_string, s1, "str__join_the_feast"),
+        (try_end),
+        ], "Talk to the lords {s1}",
+        [
+        (assign, ":center_no", "$current_town"),
+        (assign, "$talk_context", tc_court_talk),
+        (set_jump_mission, "mt_visit_town_castle"),
+        (mission_tpl_entry_clear_override_items, "mt_visit_town_castle", 0),
+        #(mission_tpl_entry_set_override_flags, "mt_visit_town_castle", 0, af_override_all),
+        (party_get_slot, ":castle_scene", ":center_no", slot_town_castle),
+        (modify_visitors_at_site, ":castle_scene"),
+        (reset_visitors),
+        (assign, ":cur_pos", 16),
+        
+        (call_script, "script_get_heroes_attached_to_center", ":center_no", "p_temp_party"),
+        (party_get_num_companion_stacks, ":num_stacks", "p_temp_party"),
+        (try_for_range, ":i_stack", 0, ":num_stacks"),
+          (party_stack_get_troop_id, ":stack_troop", "p_temp_party", ":i_stack"),
+          (lt, ":cur_pos", 32), # spawn up to entry point 32 - is it possible to add another 10 spots?
+          (set_visitor, ":cur_pos", ":stack_troop"),
+          (val_add, ":cur_pos", 1),
+        (try_end),
+        
+        (set_jump_entry, 0),
+        (jump_to_scene, ":castle_scene"),
+        (scene_set_slot, ":castle_scene", slot_scene_visited, 1),
+        (change_screen_mission),
+        ]),
+      
+      ("talk_to_ladies.",
+        [
+        (str_clear, s1),
+        (try_begin),
+          (store_faction_of_party, ":center_faction", "$current_town"),
+          (faction_slot_eq, ":center_faction", slot_faction_ai_state, sfai_feast),
+          (faction_slot_eq, ":center_faction", slot_faction_ai_object, "$current_town"),
+          (str_store_string, s1, "str__join_the_feast"),
+        (try_end),
+        ], "Talk to the ladies {s1}",
+        [
+        (assign, ":center_no", "$current_town"),
+        (assign, "$talk_context", tc_court_talk),
+        (set_jump_mission, "mt_visit_town_castle"),
+        (mission_tpl_entry_clear_override_items, "mt_visit_town_castle", 0),
+        #(mission_tpl_entry_set_override_flags, "mt_visit_town_castle", 0, af_override_all),
+        (party_get_slot, ":castle_scene", ":center_no", slot_town_castle),
+        (modify_visitors_at_site, ":castle_scene"),
+        (reset_visitors),
+        (assign, ":cur_pos", 16),
+        
+        (try_for_range, ":cur_troop", kingdom_ladies_begin, kingdom_ladies_end),
+          (neq, ":cur_troop", "trp_knight_1_1_wife"), #The one who should not appear in game
+          #(troop_slot_eq, ":cur_troop", slot_troop_occupation, slto_kingdom_lady),
+          (troop_slot_eq, ":cur_troop", slot_troop_cur_center, ":center_no"),
+          (assign, ":lady_meets_visitors", 0),
+          
+          (try_begin),
+            (this_or_next|troop_slot_eq, "trp_player", slot_troop_betrothed, ":cur_troop"),##betrothed allowed
+            (troop_slot_eq, ":cur_troop", slot_troop_betrothed, "trp_player"),
+            (assign, ":lady_meets_visitors", 1), 
+          (try_end),
+          (try_begin), 
+            (call_script, "script_get_kingdom_lady_social_determinants", ":cur_troop"),##single ladies check 
+            (gt, reg0, -1),  ####### NEW v3.0
+            (call_script, "script_npc_decision_checklist_male_guardian_assess_suitor", reg0, "trp_player"),
+            (gt, reg0, 0),
+            (assign, ":lady_meets_visitors", 1),
+          (try_end),
+          (try_begin),
+            (troop_slot_ge, ":cur_troop", slot_troop_spouse, 1),##married ladies allowed
+            (assign, ":lady_meets_visitors", 1),
+          (try_end),
+          
+          (eq, ":lady_meets_visitors", 1),
+          (lt, ":cur_pos", 32), # spawn up to entry point 32
+          (set_visitor, ":cur_pos", ":cur_troop"),
+          (val_add, ":cur_pos", 1),
+        (try_end),
+        
+        (set_jump_entry, 0),
+        (jump_to_scene, ":castle_scene"),
+        (scene_set_slot, ":castle_scene", slot_scene_visited, 1),
+        (change_screen_mission),
+        ]),
+      
+      ("continue",[], "Continue",
+        [
+        (jump_to_menu, "mnu_town"),
+        ]),
+    ]
+    ),
+####### NEW v3.1-KOMKE END- 
+    
+######################################################
+  
+
+
 
 ######################################################
 


### PR DESCRIPTION
.-Removed options to replace minister with companions or spouse
.-Temporary minister is now fully functional
.-Replaced script enter_court with new menu castle_entered, because it was too crowded in tournaments. Not enough positions for everyone.
.-Now if player enters a town or castle and has enough renown (200) he has 3 options: 
1-enter court where there are the  center lord and his wife, and the minister and advisors if player court, and the lords asking to join the faction. Also added the dialogue to ask the guard the location of any kingdom hero from that faction. (In case there is no one at the moment)
2-talk to lords where all the lords currently at the center should appear.
3-talk to ladies where all the ladies currently at the center should appear.
.-It is possible to access a tournament with 125 renown and gain access to the castle before having 200 renown.